### PR TITLE
EntityId: #nullable enable to silence CS8632

### DIFF
--- a/interfaces/dotnet/PolyPersist/Core/EntityId.cs
+++ b/interfaces/dotnet/PolyPersist/Core/EntityId.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
The IParsable signatures use nullable annotations but PolyPersist.Net has no nullable context, raising 3 CS8632 warnings. Scoped `#nullable enable` to EntityId.cs. Solution builds 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)