### PR TITLE
Fix PP-01 (CQL injection) + PP-02 (path traversal)

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.BlobStore.FileSystem/FileSystem_BlobContainer.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.BlobStore.FileSystem/FileSystem_BlobContainer.cs
@@ -126,7 +126,17 @@ namespace PolyPersist.Net.BlobStore.FileSystem
 
         private string _makeFilePath(string id)
         {
-            return Path.Combine(_containerPath, id);
+            // Resolve the path and make sure it stays inside the container: an id such as
+            // "../../etc/passwd" must not escape (path traversal). Hierarchical ids
+            // ("folder/blob") are still allowed as long as they resolve within the root.
+            string root = Path.GetFullPath(_containerPath);
+            string full = Path.GetFullPath(Path.Combine(root, id));
+            string rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+                ? root
+                : root + Path.DirectorySeparatorChar;
+            if (full.StartsWith(rootWithSeparator, StringComparison.Ordinal) == false)
+                throw new ArgumentException($"Invalid blob id '{id}': it resolves outside the container.");
+            return full;
         }
     }
 }

--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_ExpressionVisitor.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_ExpressionVisitor.cs
@@ -12,6 +12,7 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
         private string _tableName;
         private TableMetadata _tableMeta;
         private readonly List<string> _conditions = new();
+        internal readonly List<object> _parameters = new();   // bound values for '?' placeholders
         private List<string> _orderBy = new();
         private int? _limit = null;
         private bool _allowFiltering = false;
@@ -150,18 +151,27 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
                 _ => throw new NotSupportedException($"Operator '{node.NodeType}' not supported")
             };
 
-            string valStr = right switch
+            // A string value is the CQL-injection vector (a quote in the value would break
+            // out of the literal), so bind it as a positional parameter instead of
+            // interpolating it. The other types render to safe, unforgeable literals.
+            if (right is string s)
             {
-                string s => $"'{s}'",
-                DateTime dt => $"'{dt:yyyy-MM-dd HH:mm:ss}'",
-                DateOnly d => $"'{d:yyyy-MM-dd}'",
-                TimeOnly t => ((long)(t.ToTimeSpan().TotalMilliseconds * 1_000_000)).ToString(),
-                Guid g => $"'{g}'",
-                bool b => b.ToString().ToLower(),
-                _ => right.ToString()
-            };
-
-            _conditions.Add($"{left} {opSymbol} {valStr}");
+                _parameters.Add(s);
+                _conditions.Add($"{left} {opSymbol} ?");
+            }
+            else
+            {
+                string valStr = right switch
+                {
+                    DateTime dt => $"'{dt:yyyy-MM-dd HH:mm:ss}'",
+                    DateOnly d => $"'{d:yyyy-MM-dd}'",
+                    TimeOnly t => ((long)(t.ToTimeSpan().TotalMilliseconds * 1_000_000)).ToString(),
+                    Guid g => $"'{g}'",
+                    bool b => b.ToString().ToLower(),
+                    _ => right.ToString()
+                };
+                _conditions.Add($"{left} {opSymbol} {valStr}");
+            }
             return node;
         }
 

--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_Query.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_Query.cs
@@ -14,6 +14,7 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
         }
 
         internal string cql;
+        internal object[] parameters = System.Array.Empty<object>();   // bound values for '?' in cql
         internal ResultTypes resultType;
         internal Dictionary<string, string> projectionMemberMap;
         internal NewExpression projectionCtorForAnonymous;

--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_QueryProvider.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_QueryProvider.cs
@@ -46,6 +46,7 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
             return new Cassandra_Query()
             {
                 cql = cql,
+                parameters = visitor._parameters.ToArray(),
                 resultType = resultType,
                 projectionCtorForAnonymous = visitor._projectionAnonymousCtor,
                 projectionMemberMap = visitor._projectionMap,
@@ -55,7 +56,7 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
         public object Execute(Expression expression)
         {
             var query = BuildQuery(expression);
-            RowSet rs = _table._session.Execute(new SimpleStatement(query.cql));
+            RowSet rs = _table._session.Execute(new SimpleStatement(query.cql, query.parameters));
 
             if (expression.Type == typeof(int))
             {

--- a/tests/dotnet/PolyPersist.Net.BlobStore.Tests/FileSystem_Security_Tests.cs
+++ b/tests/dotnet/PolyPersist.Net.BlobStore.Tests/FileSystem_Security_Tests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PolyPersist;
+using PolyPersist.Net.BlobStore.FileSystem;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace PolyPersist.Net.BlobStore.Tests
+{
+    // PP-02: the FileSystem blob store must not let a path-traversal id escape the container.
+    [TestClass]
+    public class FileSystem_Security_Tests
+    {
+        [TestMethod]
+        public async Task Find_WithTraversalId_Throws()
+        {
+            string basePath = Path.Combine(Path.GetTempPath(), "pp_fs_sec_" + Guid.NewGuid().ToString("N"));
+            IBlobStore store = new FileSystem_BlobStore(basePath);
+            IBlobContainer<SampleBlob> container = await store.CreateContainer<SampleBlob>("sec");
+            try
+            {
+                await Assert.ThrowsExceptionAsync<ArgumentException>(
+                    async () => await container.Find("pk", "../../escape.txt"));
+            }
+            finally
+            {
+                if (Directory.Exists(basePath))
+                    Directory.Delete(basePath, true);
+            }
+        }
+    }
+}

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,49 @@
+TODO — PolyPersist   (from the MicronIQ roadmap review + code analysis, 2026-07-07)
+
+Build: `dotnet build implementations/dotnet/PolyPersist.Net.sln` -> succeeds (net8.0,
+0 errors). The issues below are runtime correctness / security / test gaps, not build
+errors. We go through these ONE BY ONE.
+
+== P0 — critical ==
+[ ] PP-01  CQL injection (Cassandra): Cassandra_ExpressionVisitor interpolates values
+           straight into CQL (`$"'{s}'"`). Fix: parameter binding / bound statements.
+[ ] PP-02  Path traversal (FileSystem blob): _makeFilePath = Path.Combine(container, id)
+           with an unsanitized id -> `../..` escapes. Fix: validate id / keep the
+           resolved path inside the container.
+[by design] PP-03  "No real atomicity": INTENTIONAL — the transaction is optimistic
+           (runs eagerly, compensates/rolls back on failure). This is a deliberate design
+           choice, hard to do otherwise. NOT a defect; dropped from the backlog.
+[ ] PP-04  Zero transaction test coverage. (Still wanted even though PP-03 is by design.)
+
+== P1 — high ==
+[ ] PP-05  No PostgreSQL (Relational) implementation.
+[ ] PP-06  No EventStoreDB implementation (central to the event-sourcing vision).
+[ ] PP-10  Rollback runs in parallel against Reverse() ordering.
+[ ] PP-11  Pre-commit flag blocks compensation (Commit sets _committed=1 before the ops).
+[ ] PP-14  Mongo Update mutates etag/LastUpdate BEFORE the write (not after success).
+[ ] PP-15  Memory column Find ignores partitionKey (matches on id only).
+[ ] PP-16  CQL WHERE: bare AND/OR, no `!=`, no parentheses.
+[ ] PP-17  LINQ scalar/bool branches return null (Cassandra_QueryProvider empty branches).
+[ ] PP-18  Blob (?): no partitionKey, no etag, truncation on write.
+[ ] PP-19  Blob object key = blob.id only (no partitionKey in key, no etag).
+[ ] PP-20  GridFS Delete can orphan chunks (deletes metadata doc first).
+[ ] PP-21  Untyped exceptions everywhere (bare Exception). Refactor to typed exceptions.
+[ ] PP-30  Cassandra/Scylla effectively untested (setup commented out).
+
+== P2 — medium ==
+[ ] PP-07  No OpenSearch implementation (search/index store).
+[ ] PP-08  No ClickHouse implementation (analytics store).
+[ ] PP-09  No Redis / KeyValue implementation (cache store).
+[ ] PP-12  Entity-tracking key collisions ({TypeName}_{id} ignores partitionKey).
+[ ] PP-13  Dispose sync-over-async deadlock risk (Rollback().GetAwaiter().GetResult()).
+[ ] PP-22  Memory Document Delete ignores partitionKey (id-only).
+[ ] PP-23  DateTime.Now vs UtcNow inconsistency (Memory Document/Column Update).
+[ ] PP-24  Debug + copy-paste + wasteful ops (Console.WriteLine in Find hot path, etc.).
+[ ] PP-25  LINQ FROM without keyspace (QueryProvider uses `FROM {table}`).
+[ ] PP-26  Existence-check / metadata-update waste (S3 GetObjectAsync full download).
+[ ] PP-27  LINQ provider expression coverage (only member<op>constant supported).
+[ ] PP-29  Generated Java/Python/Rust interfaces missing (only .gitkeep).
+[ ] PP-31  Cloud blob cross-partition isolation never tested.
+
+== P3 — low ==
+[ ] PP-28  Java/Python/Rust implementations empty (only .gitkeep).


### PR DESCRIPTION
**PP-01 (CQL injection):** the Cassandra LINQ provider interpolated string values straight into CQL (`$"'{s}'"`). Now binds strings as positional parameters (`?` + `SimpleStatement(cql, params)`); other types stay safe literals.

**PP-02 (path traversal):** the FileSystem blob store used `Path.Combine(container, id)` with an unsanitized id, so `../..` escaped. Now resolves the full path and rejects anything outside the container root (hierarchical ids still allowed). Passing traversal test added.

Solution builds 0 warnings / 0 errors. `todo.txt` records the full PolyPersist backlog to work through one by one (PP-03 = by design: the optimistic run-then-compensate transaction is intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)