### PR TITLE
PP-04: transaction tests + fix Update/Delete rollback

### DIFF
--- a/implementations/dotnet/PolyPersist.Net.sln
+++ b/implementations/dotnet/PolyPersist.Net.sln
@@ -57,6 +57,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Files", ".Solutio
 		..\..\README.md = ..\..\README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolyPersist.Net.Transactions.Tests", "..\..\tests\dotnet\PolyPersist.Net.Transactions.Tests\PolyPersist.Net.Transactions.Tests.csproj", "{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -271,6 +273,18 @@ Global
 		{E052D589-6674-4164-ABB1-4D3611736487}.Release|x64.Build.0 = Release|Any CPU
 		{E052D589-6674-4164-ABB1-4D3611736487}.Release|x86.ActiveCfg = Release|Any CPU
 		{E052D589-6674-4164-ABB1-4D3611736487}.Release|x86.Build.0 = Release|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Debug|x64.Build.0 = Debug|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Debug|x86.Build.0 = Debug|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Release|x64.ActiveCfg = Release|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Release|x64.Build.0 = Release|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Release|x86.ActiveCfg = Release|Any CPU
+		{424FCDD1-0C6B-40BA-AC2C-0FDF8B09C74E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
@@ -157,6 +157,7 @@ namespace PolyPersist.Net.Transactions
             _rollBackActions.Add(async () =>
             {
                 TDocument original = JsonSerializer.Deserialize<TDocument>(_deepCloneOfEntities[key].Json);
+                original.etag = document.etag;   // adopt the current etag so the optimistic-concurrency check passes
                 await collection.Update(original).ConfigureAwait(false);
             });
         }
@@ -184,6 +185,7 @@ namespace PolyPersist.Net.Transactions
             _rollBackActions.Add(async () =>
             {
                 TRow original = JsonSerializer.Deserialize<TRow>(_deepCloneOfEntities[key].Json);
+                original.etag = row.etag;   // adopt the current etag so the optimistic-concurrency check passes
                 await table.Update(original).ConfigureAwait(false);
             });
         }
@@ -267,6 +269,7 @@ namespace PolyPersist.Net.Transactions
             _rollBackActions.Add(async () =>
             {
                 TBlob original = JsonSerializer.Deserialize<TBlob>(_deepCloneOfEntities[key].Json);
+                original.etag = blob.etag;   // adopt the current etag so the optimistic-concurrency check passes
                 await container.UpdateMetadata(original).ConfigureAwait(false);
             });
         }
@@ -294,6 +297,7 @@ namespace PolyPersist.Net.Transactions
             _rollBackActions.Add(async () =>
             {
                 TDocument original = JsonSerializer.Deserialize<TDocument>(_deepCloneOfEntities[key].Json);
+                original.etag = null;   // Insert requires an empty etag; it assigns a fresh one
                 await collection.Insert(original).ConfigureAwait(false);
             });
         }
@@ -321,6 +325,7 @@ namespace PolyPersist.Net.Transactions
             _rollBackActions.Add(async () =>
             {
                 TRow original = JsonSerializer.Deserialize<TRow>(_deepCloneOfEntities[key].Json);
+                original.etag = null;   // Insert requires an empty etag; it assigns a fresh one
                 await table.Insert(original).ConfigureAwait(false);
             });
         }
@@ -348,6 +353,7 @@ namespace PolyPersist.Net.Transactions
             _rollBackActions.Add(async () =>
             {
                 TBlob original = JsonSerializer.Deserialize<TBlob>(_deepCloneOfEntities[key].Json);
+                original.etag = null;   // Upload requires an empty etag; it assigns a fresh one
                 var originalContent = _deepCloneOfEntities[key].Content;
                 using var ms = new MemoryStream(originalContent.Span.ToArray(), writable: false);
                 await container.Upload(original, ms).ConfigureAwait(false);

--- a/tests/dotnet/PolyPersist.Net.Transactions.Tests/PolyPersist.Net.Transactions.Tests.csproj
+++ b/tests/dotnet/PolyPersist.Net.Transactions.Tests/PolyPersist.Net.Transactions.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.Transactions\PolyPersist.Net.Transactions.csproj" />
+    <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.DocumentStore.Memory\PolyPersist.Net.DocumentStore.Memory.csproj" />
+    <ProjectReference Include="..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
+++ b/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
@@ -1,0 +1,103 @@
+using PolyPersist;
+using PolyPersist.Net.Core;
+using PolyPersist.Net.DocumentStore.Memory;
+using PolyPersist.Net.Transactions;
+
+namespace PolyPersist.Net.Transactions.Tests
+{
+    // PP-04: first test coverage for the (optimistic, run-then-compensate) transaction.
+    // Uses the in-memory document store, so it needs no external database / Docker.
+    public class TxDoc : Entity, IDocument
+    {
+        public string str_value { get; set; }
+    }
+
+    [TestClass]
+    public class TransactionTests
+    {
+        private static async Task<IDocumentCollection<TxDoc>> NewCollectionAsync()
+        {
+            IDocumentStore store = new Memory_DocumentStore("");
+            return await store.CreateCollection<TxDoc>("txcol");
+        }
+
+        [TestMethod]
+        public async Task Insert_Commit_KeepsDocument()
+        {
+            var col = await NewCollectionAsync();
+            var tx = new Transaction();
+            await tx.Insert(col, new TxDoc { PartitionKey = "pk", id = "a", str_value = "x" });
+            await tx.Commit();
+
+            Assert.IsNotNull(await col.Find("pk", "a"));
+        }
+
+        [TestMethod]
+        public async Task Insert_Rollback_RemovesDocument()
+        {
+            var col = await NewCollectionAsync();
+            var tx = new Transaction();
+            await tx.Insert(col, new TxDoc { PartitionKey = "pk", id = "a", str_value = "x" });
+            await tx.Rollback();
+
+            Assert.IsNull(await col.Find("pk", "a"));
+        }
+
+        [TestMethod]
+        public async Task Insert_DisposeWithoutCommit_RollsBack()
+        {
+            var col = await NewCollectionAsync();
+            await using (var tx = new Transaction())
+            {
+                await tx.Insert(col, new TxDoc { PartitionKey = "pk", id = "a", str_value = "x" });
+            } // leaving the scope without Commit -> auto rollback
+
+            Assert.IsNull(await col.Find("pk", "a"));
+        }
+
+        [TestMethod]
+        public async Task Update_Rollback_RestoresOriginal()
+        {
+            var col = await NewCollectionAsync();
+            var doc = new TxDoc { PartitionKey = "pk", id = "a", str_value = "original" };
+            await col.Insert(doc);
+
+            var tx = new Transaction();
+            tx.AddOriginal(col, doc);
+            doc.str_value = "changed";
+            await tx.Update(col, doc);
+            await tx.Rollback();
+
+            var found = await col.Find("pk", "a");
+            Assert.IsNotNull(found);
+            Assert.AreEqual("original", found.str_value);
+        }
+
+        [TestMethod]
+        public async Task Delete_Rollback_ReInsertsDocument()
+        {
+            var col = await NewCollectionAsync();
+            var doc = new TxDoc { PartitionKey = "pk", id = "a", str_value = "x" };
+            await col.Insert(doc);
+
+            var tx = new Transaction();
+            tx.AddOriginal(col, doc);
+            await tx.Delete(col, doc);
+            await tx.Rollback();
+
+            Assert.IsNotNull(await col.Find("pk", "a"));
+        }
+
+        [TestMethod]
+        public async Task Rollback_AfterCommit_IsNoOp()
+        {
+            var col = await NewCollectionAsync();
+            var tx = new Transaction();
+            await tx.Insert(col, new TxDoc { PartitionKey = "pk", id = "a", str_value = "x" });
+            await tx.Commit();
+            await tx.Rollback(); // already committed -> must not undo the insert
+
+            Assert.IsNotNull(await col.Find("pk", "a"));
+        }
+    }
+}

--- a/todo.txt
+++ b/todo.txt
@@ -13,7 +13,13 @@ errors. We go through these ONE BY ONE.
 [by design] PP-03  "No real atomicity": INTENTIONAL — the transaction is optimistic
            (runs eagerly, compensates/rolls back on failure). This is a deliberate design
            choice, hard to do otherwise. NOT a defect; dropped from the backlog.
-[ ] PP-04  Zero transaction test coverage. (Still wanted even though PP-03 is by design.)
+[x] PP-04  Transaction test coverage — DONE. New PolyPersist.Net.Transactions.Tests project
+           (in-memory store, no Docker), 6 tests: Insert+Commit keeps, Insert+Rollback removes,
+           Dispose-without-Commit auto-rolls-back, Update+Rollback restores, Delete+Rollback
+           re-inserts, Rollback-after-Commit is a no-op. The tests revealed and FIXED two
+           real compensation bugs: Update-rollback failed the optimistic etag check (now
+           adopts the current etag) and Delete-rollback re-inserted with a filled etag (now
+           cleared before Insert/Upload). Fixes cover doc + row + blob variants.
 
 == P1 — high ==
 [ ] PP-05  No PostgreSQL (Relational) implementation.


### PR DESCRIPTION
New `PolyPersist.Net.Transactions.Tests` (in-memory store, no Docker) — first coverage for the optimistic transaction: Insert+Commit, Insert+Rollback, Dispose auto-rollback, Update+Rollback, Delete+Rollback, Rollback-after-Commit no-op.

Writing them surfaced **two real compensation bugs** (rollback silently threw), now fixed:
- **Update rollback** used the original's stale etag → failed the optimistic check. Now adopts the current etag.
- **Delete rollback** re-inserted with a filled etag → Insert/Upload rejected it. Now cleared first.

Both cover the document/row/blob variants. Solution builds 0/0; **6 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)