### PR TITLE
PP-10: rollback compensations run sequentially in reverse order

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
@@ -15,9 +15,11 @@ namespace PolyPersist.Net.Transactions
         // Holds deep-cloned state of tracked entities (JSON + blob content)
         // Reason: multiple threads might AddOriginal concurrently in rare cases. eg: Task.WhenAll( ... ) for multiple objects
         private readonly ConcurrentDictionary<string, _EntityData> _deepCloneOfEntities = [];
-        // List of rollback actions to revert state if the transaction is aborted
-        // Reason: rollback actions might be added from different threads. eg: Task.WhenAll( ... ) for multiple objects
-        private readonly ConcurrentBag<Func<ValueTask>> _rollBackActions = [];
+        // List of rollback actions to revert state if the transaction is aborted.
+        // A queue (not a bag) so insertion order is preserved: rollback runs them in reverse
+        // (LIFO) so later operations are compensated before the ones they may depend on.
+        // ConcurrentQueue is still thread-safe for concurrent Enqueue (eg. Task.WhenAll).
+        private readonly ConcurrentQueue<Func<ValueTask>> _rollBackActions = new();
         // List of commit actions to finalize state when the transaction succeeds
         // Reason: commit actions might be added from different threads. eg: Task.WhenAll( ... ) for multiple objects
         private readonly ConcurrentBag<Func<ValueTask>> _commitActions = [];
@@ -109,7 +111,7 @@ namespace PolyPersist.Net.Transactions
             await collection.Insert(document).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Insert, document));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 await collection.Delete(document.PartitionKey, document.id).ConfigureAwait(false);
             });
@@ -128,7 +130,7 @@ namespace PolyPersist.Net.Transactions
             await table.Insert(row).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Insert, row));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 await table.Delete(row.PartitionKey, row.id).ConfigureAwait(false);
             });
@@ -154,7 +156,7 @@ namespace PolyPersist.Net.Transactions
             await collection.Update(document).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Update, document));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 TDocument original = JsonSerializer.Deserialize<TDocument>(_deepCloneOfEntities[key].Json);
                 original.etag = document.etag;   // adopt the current etag so the optimistic-concurrency check passes
@@ -182,7 +184,7 @@ namespace PolyPersist.Net.Transactions
             await table.Update(row).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Update, row));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 TRow original = JsonSerializer.Deserialize<TRow>(_deepCloneOfEntities[key].Json);
                 original.etag = row.etag;   // adopt the current etag so the optimistic-concurrency check passes
@@ -211,7 +213,7 @@ namespace PolyPersist.Net.Transactions
             await container.Upload(blob, content).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Insert, blob));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 await container.Delete(blob.PartitionKey, blob.id).ConfigureAwait(false);
             });
@@ -238,7 +240,7 @@ namespace PolyPersist.Net.Transactions
             await container.UpdateContent(blob, content).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Update, blob));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 var originalContent = _deepCloneOfEntities[key].Content;
                 using var ms = new MemoryStream(originalContent.ToArray(), writable: false);
@@ -266,7 +268,7 @@ namespace PolyPersist.Net.Transactions
             await container.UpdateMetadata(blob).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Update, blob));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 TBlob original = JsonSerializer.Deserialize<TBlob>(_deepCloneOfEntities[key].Json);
                 original.etag = blob.etag;   // adopt the current etag so the optimistic-concurrency check passes
@@ -294,7 +296,7 @@ namespace PolyPersist.Net.Transactions
             await collection.Delete(document.PartitionKey, document.id).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Delete, document));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 TDocument original = JsonSerializer.Deserialize<TDocument>(_deepCloneOfEntities[key].Json);
                 original.etag = null;   // Insert requires an empty etag; it assigns a fresh one
@@ -322,7 +324,7 @@ namespace PolyPersist.Net.Transactions
             await table.Delete(row.PartitionKey, row.id).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Delete, row));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 TRow original = JsonSerializer.Deserialize<TRow>(_deepCloneOfEntities[key].Json);
                 original.etag = null;   // Insert requires an empty etag; it assigns a fresh one
@@ -350,7 +352,7 @@ namespace PolyPersist.Net.Transactions
             await container.Delete(blob.PartitionKey, blob.id).ConfigureAwait(false);
             _executedOperations.Add((ITransaction.Operations.Delete, blob));
 
-            _rollBackActions.Add(async () =>
+            _rollBackActions.Enqueue(async () =>
             {
                 TBlob original = JsonSerializer.Deserialize<TBlob>(_deepCloneOfEntities[key].Json);
                 original.etag = null;   // Upload requires an empty etag; it assigns a fresh one
@@ -385,7 +387,7 @@ namespace PolyPersist.Net.Transactions
         /// Adds a custom rollback action to the transaction.
         /// </summary>
         /// <param name="action">The asynchronous action to perform during rollback.</param>
-        public void AddRollBackAction(Func<ValueTask> action) => _rollBackActions.Add(action);
+        public void AddRollBackAction(Func<ValueTask> action) => _rollBackActions.Enqueue(action);
 
         /// <summary>
         /// Rolls back the transaction by executing all registered rollback actions in parallel.
@@ -406,7 +408,11 @@ namespace PolyPersist.Net.Transactions
         // Reason: Allows all rollback steps to be attempted even if some fail.
         private static async Task _ExecuteSafely(IEnumerable<Func<ValueTask>> actions, [CallerMemberName] string function = "")
         {
-            var tasks = actions.Select(async action =>
+            // Run sequentially in the given order (Rollback passes them reversed), so a later
+            // operation is compensated before the earlier one it may depend on. Best-effort:
+            // keep going after a failure and aggregate the errors at the end.
+            var exceptions = new List<Exception>();
+            foreach (var action in actions)
             {
                 try
                 {
@@ -414,13 +420,9 @@ namespace PolyPersist.Net.Transactions
                 }
                 catch (Exception ex)
                 {
-                    return ex;
+                    exceptions.Add(ex);
                 }
-                return null;
-            });
-
-            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-            var exceptions = results.Where(ex => ex != null).Cast<Exception>().ToList();
+            }
 
             if (exceptions.Any())
                 throw new AggregateException($"One or more actions failed in {function}.", exceptions);

--- a/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
+++ b/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
@@ -99,5 +99,35 @@ namespace PolyPersist.Net.Transactions.Tests
 
             Assert.IsNotNull(await col.Find("pk", "a"));
         }
+
+        // PP-10: rollback must run the compensations sequentially in REVERSE order (LIFO),
+        // so a later operation is undone before the earlier one it may depend on.
+        [TestMethod]
+        public async Task Rollback_RunsCompensationsInReverseOrder()
+        {
+            var spy = new RecordingCollection<TxDoc>();
+            var tx = new Transaction();
+            await tx.Insert(spy, new TxDoc { PartitionKey = "pk", id = "A" });
+            await tx.Insert(spy, new TxDoc { PartitionKey = "pk", id = "B" });
+            await tx.Insert(spy, new TxDoc { PartitionKey = "pk", id = "C" });
+
+            await tx.Rollback();
+
+            CollectionAssert.AreEqual(new[] { "C", "B", "A" }, spy.DeleteOrder);
+        }
+
+        // records the order of Delete calls (the Insert compensation); other members are no-ops
+        private sealed class RecordingCollection<TDoc> : IDocumentCollection<TDoc> where TDoc : IDocument, new()
+        {
+            public readonly List<string> DeleteOrder = new();
+            public IStore ParentStore => null;
+            public string Name => "spy";
+            public Task Insert(TDoc document) => Task.CompletedTask;
+            public Task Update(TDoc document) => Task.CompletedTask;
+            public Task Delete(string partitionKey, string id) { DeleteOrder.Add(id); return Task.CompletedTask; }
+            public Task<TDoc> Find(string partitionKey, string id) => Task.FromResult(default(TDoc));
+            public object Query<T>() where T : TDoc, new() => null;
+            public object GetUnderlyingImplementation() => null;
+        }
     }
 }

--- a/todo.txt
+++ b/todo.txt
@@ -24,7 +24,11 @@ errors. We go through these ONE BY ONE.
 == P1 — high ==
 [ ] PP-05  No PostgreSQL (Relational) implementation.
 [ ] PP-06  No EventStoreDB implementation (central to the event-sourcing vision).
-[ ] PP-10  Rollback runs in parallel against Reverse() ordering.
+[x] PP-10  Rollback ordering — DONE. `_rollBackActions` was a ConcurrentBag (no insertion
+           order) executed via Task.WhenAll (concurrent), so `.Reverse()` was meaningless.
+           Now a ConcurrentQueue (order-preserving, still thread-safe) executed SEQUENTIALLY
+           in reverse (LIFO), so a later op is compensated before the earlier one it depends
+           on. Added a spy-collection test asserting reverse Delete order (A,B,C -> C,B,A).
 [ ] PP-11  Pre-commit flag blocks compensation (Commit sets _committed=1 before the ops).
 [ ] PP-14  Mongo Update mutates etag/LastUpdate BEFORE the write (not after success).
 [ ] PP-15  Memory column Find ignores partitionKey (matches on id only).


### PR DESCRIPTION
`_rollBackActions` was a ConcurrentBag (no insertion order) executed via `Task.WhenAll` (concurrent), so the `.Reverse()` in Rollback had no effect.

Now it is a **ConcurrentQueue** (order-preserving, still thread-safe) and `_ExecuteSafely` runs actions **sequentially** in order, so rollback compensates in **reverse (LIFO)** — a later op is undone before the earlier one it may depend on. Still best-effort (aggregates errors).

Spy-collection test asserts reverse Delete order (A,B,C → C,B,A). 7 transaction tests green; builds 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)