### PR TITLE
PP-11: mark committed only after commit actions succeed

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
@@ -29,7 +29,10 @@ namespace PolyPersist.Net.Transactions
 
         // Tracks whether Dispose/DisposeAsync was called(Interlocked used for thread-safety).
         private int _disposed;
-        // Tracks whether Commit() succeeded. Volatile for lock-free checks.
+        // Tracks whether a Commit() has started (guards against double/concurrent commit).
+        private int _commitStarted;
+        // Tracks whether Commit() succeeded. Volatile for lock-free checks. Set only AFTER
+        // the commit actions ran, so a failed commit does not block Rollback().
         private int _committed;
 
         /// <summary>
@@ -375,11 +378,16 @@ namespace PolyPersist.Net.Transactions
         /// <returns>A task that represents the asynchronous commit operation.</returns>
         public async Task Commit()
         {
-            // is already committed ?
-            if (Interlocked.Exchange(ref _committed, 1) == 1)
+            // guard against double / concurrent Commit
+            if (Interlocked.Exchange(ref _commitStarted, 1) == 1)
                 return;
 
+            // Run the commit actions FIRST and only mark the transaction committed if they
+            // all succeed. If a commit action throws, _committed stays 0, so Rollback() and
+            // Dispose() can still compensate the already-executed operations.
             await _ExecuteSafely(_commitActions).ConfigureAwait(false);
+
+            Volatile.Write(ref _committed, 1);
             _Clear();
         }
 

--- a/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
+++ b/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
@@ -116,6 +116,22 @@ namespace PolyPersist.Net.Transactions.Tests
             CollectionAssert.AreEqual(new[] { "C", "B", "A" }, spy.DeleteOrder);
         }
 
+        // PP-11: a failing commit action must NOT mark the transaction committed, so the
+        // already-executed operations can still be rolled back (compensation not blocked).
+        [TestMethod]
+        public async Task Commit_WhenCommitActionFails_StillAllowsRollback()
+        {
+            var col = await NewCollectionAsync();
+            var tx = new Transaction();
+            await tx.Insert(col, new TxDoc { PartitionKey = "pk", id = "a", str_value = "x" });
+            tx.AddCommitAction(() => throw new InvalidOperationException("commit boom"));
+
+            await Assert.ThrowsExceptionAsync<AggregateException>(() => tx.Commit());
+
+            await tx.Rollback(); // must still compensate the insert
+            Assert.IsNull(await col.Find("pk", "a"));
+        }
+
         // records the order of Delete calls (the Insert compensation); other members are no-ops
         private sealed class RecordingCollection<TDoc> : IDocumentCollection<TDoc> where TDoc : IDocument, new()
         {

--- a/todo.txt
+++ b/todo.txt
@@ -29,7 +29,12 @@ errors. We go through these ONE BY ONE.
            Now a ConcurrentQueue (order-preserving, still thread-safe) executed SEQUENTIALLY
            in reverse (LIFO), so a later op is compensated before the earlier one it depends
            on. Added a spy-collection test asserting reverse Delete order (A,B,C -> C,B,A).
-[ ] PP-11  Pre-commit flag blocks compensation (Commit sets _committed=1 before the ops).
+[x] PP-11  Pre-commit flag blocks compensation — DONE. Commit set _committed=1 BEFORE running
+           the commit actions, so a failing commit action left the tx marked committed and
+           Rollback()/Dispose() no-opped (compensation blocked). Now a separate _commitStarted
+           guards double-commit and _committed is set only AFTER the commit actions succeed, so
+           a failed commit still allows rollback. Test: Insert + failing AddCommitAction ->
+           Commit throws -> Rollback still removes the insert.
 [ ] PP-14  Mongo Update mutates etag/LastUpdate BEFORE the write (not after success).
 [ ] PP-15  Memory column Find ignores partitionKey (matches on id only).
 [ ] PP-16  CQL WHERE: bare AND/OR, no `!=`, no parentheses.


### PR DESCRIPTION
`Commit()` set `_committed=1` **before** running the commit actions (`AddCommitAction`), so a failing commit action left the tx flagged committed and `Rollback()`/`Dispose()` no-opped — compensation blocked.

Now a separate `_commitStarted` guards double-commit and `_committed` is set only **after** the commit actions succeed, so a failed commit still allows rollback.

Test: Insert + failing commit action → Commit throws → Rollback still removes the insert. 8 transaction tests green; builds 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)