### PR TITLE
PP-15: Memory column Find/Delete respect partitionKey

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Memory/Memory_ColumnTable.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Memory/Memory_ColumnTable.cs
@@ -73,7 +73,8 @@ namespace PolyPersist.Net.ColumnStore.Memory
         /// <inheritdoc/>
         Task IColumnTable<TRow>.Delete(string partitionKey, string id)
         {
-            if (_tableData.MapOfDocments.TryGetValue(id, out _RowData row) == false)
+            // only delete when the row exists in the requested partition
+            if (_tableData.MapOfDocments.TryGetValue(id, out _RowData row) == false || row.partitionKey != partitionKey)
                 throw new Exception($"Row '{typeof(TRow).Name}' {id} can not be removed because it is already removed");
 
             _tableData.MapOfDocments.Remove(id);
@@ -85,7 +86,9 @@ namespace PolyPersist.Net.ColumnStore.Memory
         /// <inheritdoc/>
         Task<TRow> IColumnTable<TRow>.Find(string partitionKey, string id)
         {
-            if (_tableData.MapOfDocments.TryGetValue(id, out _RowData row) == true)
+            // the row is identified by (partitionKey, id): a matching id in a different
+            // partition is not the requested row.
+            if (_tableData.MapOfDocments.TryGetValue(id, out _RowData row) == true && row.partitionKey == partitionKey)
                 return Task.FromResult(JsonSerializer.Deserialize<TRow>(row.Value, JsonOptionsProvider.Options()));
 
             return Task.FromResult<TRow>((TRow)default(TRow));

--- a/tests/dotnet/PolyPersist.Net.ColumnStore.Tests/Memory_PartitionKey_Tests.cs
+++ b/tests/dotnet/PolyPersist.Net.ColumnStore.Tests/Memory_PartitionKey_Tests.cs
@@ -1,0 +1,35 @@
+using PolyPersist;
+using PolyPersist.Net.ColumnStore.Memory;
+using System;
+using System.Threading.Tasks;
+
+namespace PolyPersist.Net.ColumnStore.Tests
+{
+    // PP-15: the in-memory column table must key Find/Delete on (partitionKey, id), not id
+    // alone. Runs against the in-memory store, so it needs no Docker.
+    [TestClass]
+    public class Memory_PartitionKey_Tests
+    {
+        [TestMethod]
+        public async Task Find_RespectsPartitionKey()
+        {
+            IColumnStore store = new Memory_ColumnStore("");
+            var table = await store.CreateTable<SampleRow>("pptable");
+            await table.Insert(new SampleRow { PartitionKey = "p1", id = "a", str_value = "x" });
+
+            Assert.IsNotNull(await table.Find("p1", "a")); // right partition -> found
+            Assert.IsNull(await table.Find("p2", "a"));    // wrong partition -> not found
+        }
+
+        [TestMethod]
+        public async Task Delete_RespectsPartitionKey()
+        {
+            IColumnStore store = new Memory_ColumnStore("");
+            var table = await store.CreateTable<SampleRow>("pptable");
+            await table.Insert(new SampleRow { PartitionKey = "p1", id = "a", str_value = "x" });
+
+            await Assert.ThrowsExceptionAsync<Exception>(async () => await table.Delete("p2", "a"));
+            Assert.IsNotNull(await table.Find("p1", "a")); // wrong-partition delete left it intact
+        }
+    }
+}

--- a/todo.txt
+++ b/todo.txt
@@ -36,7 +36,11 @@ errors. We go through these ONE BY ONE.
            a failed commit still allows rollback. Test: Insert + failing AddCommitAction ->
            Commit throws -> Rollback still removes the insert.
 [ ] PP-14  Mongo Update mutates etag/LastUpdate BEFORE the write (not after success).
-[ ] PP-15  Memory column Find ignores partitionKey (matches on id only).
+[x] PP-15  Memory column Find/Delete ignored partitionKey — DONE. MapOfDocments is keyed by
+           id alone; Find/Delete now also check the stored row.partitionKey matches the
+           requested one (a matching id in another partition is not the row). Docker-free
+           tests: Find/Delete respect partitionKey. (Deeper: the id-only map still can't hold
+           same-id-different-partition rows — related to PP-12, left for later.)
 [ ] PP-16  CQL WHERE: bare AND/OR, no `!=`, no parentheses.
 [ ] PP-17  LINQ scalar/bool branches return null (Cassandra_QueryProvider empty branches).
 [ ] PP-18  Blob (?): no partitionKey, no etag, truncation on write.


### PR DESCRIPTION
`Memory_ColumnTable` keyed `MapOfDocments` by id alone, so Find/Delete matched any row with that id regardless of partition (returning/deleting rows from the wrong partition). Both now also require the stored `row.partitionKey` to match the requested one. Docker-free tests added.

(The id-only map still can't hold same-id-different-partition rows — related to PP-12, left for later.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)