### PR TITLE
PP-22: Memory Document Delete respects partitionKey

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.DocumentStore.Memory/Memory_DocumentCollection.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.DocumentStore.Memory/Memory_DocumentCollection.cs
@@ -72,7 +72,9 @@ namespace PolyPersist.Net.DocumentStore.Memory
         /// <inheritdoc/>
         Task IDocumentCollection<TDocument>.Delete(string partitionKey, string id)
         {
-            if (_collectionData.MapOfDocments.TryGetValue(id, out _RowData row) == false )
+            // only delete when the document exists in the requested partition (Find already
+            // checks this; Delete used to match on id alone)
+            if (_collectionData.MapOfDocments.TryGetValue(id, out _RowData row) == false || row.partitionKey != partitionKey)
                 throw new Exception($"Document '{typeof(TDocument).Name}' {id} can not be removed because it is already removed");
 
             _collectionData.MapOfDocments.Remove(id);

--- a/tests/dotnet/PolyPersist.Net.DocumentStore.Tests/Memory_PartitionKey_Tests.cs
+++ b/tests/dotnet/PolyPersist.Net.DocumentStore.Tests/Memory_PartitionKey_Tests.cs
@@ -1,0 +1,27 @@
+using PolyPersist;
+using PolyPersist.Net.DocumentStore.Memory;
+using System;
+using System.Threading.Tasks;
+
+namespace PolyPersist.Net.DocumentStore.Tests
+{
+    // PP-22: the in-memory document collection Delete must respect the partitionKey
+    // (it used to match on id alone). Runs against the in-memory store, so no Docker.
+    [TestClass]
+    public class Memory_PartitionKey_Tests
+    {
+        [TestMethod]
+        public async Task Delete_RespectsPartitionKey()
+        {
+            IDocumentStore store = new Memory_DocumentStore("");
+            var col = await store.CreateCollection<SampleDocument>("ppcol");
+            await col.Insert(new SampleDocument { PartitionKey = "p1", id = "a", str_value = "x" });
+
+            await Assert.ThrowsExceptionAsync<Exception>(async () => await col.Delete("p2", "a"));
+            Assert.IsNotNull(await col.Find("p1", "a")); // wrong-partition delete left it intact
+
+            await col.Delete("p1", "a"); // right partition -> removed
+            Assert.IsNull(await col.Find("p1", "a"));
+        }
+    }
+}

--- a/todo.txt
+++ b/todo.txt
@@ -55,7 +55,8 @@ errors. We go through these ONE BY ONE.
 [ ] PP-09  No Redis / KeyValue implementation (cache store).
 [ ] PP-12  Entity-tracking key collisions ({TypeName}_{id} ignores partitionKey).
 [ ] PP-13  Dispose sync-over-async deadlock risk (Rollback().GetAwaiter().GetResult()).
-[ ] PP-22  Memory Document Delete ignores partitionKey (id-only).
+[x] PP-22  Memory Document Delete ignored partitionKey — DONE. Find already checked it; Delete
+           now also requires row.partitionKey to match. Docker-free test.
 [ ] PP-23  DateTime.Now vs UtcNow inconsistency (Memory Document/Column Update).
 [ ] PP-24  Debug + copy-paste + wasteful ops (Console.WriteLine in Find hot path, etc.).
 [ ] PP-25  LINQ FROM without keyspace (QueryProvider uses `FROM {table}`).


### PR DESCRIPTION
`Memory_DocumentCollection.Find` already checked the partitionKey, but `Delete` matched on id alone (could remove a doc from the wrong partition). Delete now also requires the stored `row.partitionKey` to match. Docker-free test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)