### PR TITLE
PP-14: don't leave a new etag after a failed Mongo Update

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.DocumentStore.MongoDB/MongoDB_DocumentCollection.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.DocumentStore.MongoDB/MongoDB_DocumentCollection.cs
@@ -47,12 +47,19 @@ namespace PolyPersist.Net.DocumentStore.MongoDB
             CollectionCommon.CheckBeforeUpdate(document);
 
             string oldETag = document.etag;
+            DateTime oldLastUpdate = document.LastUpdate;
             document.etag = Guid.NewGuid().ToString();
             document.LastUpdate = DateTime.UtcNow;
 
             var result = await _mongoCollection.ReplaceOneAsync(e => e.id == document.id && e.PartitionKey == document.PartitionKey && e.etag == oldETag, document).ConfigureAwait(false);
             if (result.IsAcknowledged == false || result.ModifiedCount != 1)
+            {
+                // the write did not happen (optimistic-concurrency miss / not found): restore the
+                // caller's entity so it is not left with a new etag that was never persisted.
+                document.etag = oldETag;
+                document.LastUpdate = oldLastUpdate;
                 throw new Exception($"Document '{typeof(TDocument).Name}' {document.id} can not be updated because does not exist.");
+            }
         }
 
         /// <inheritdoc/>

--- a/tests/dotnet/PolyPersist.Net.DocumentStore.Tests/DocumentStoreTests.cs
+++ b/tests/dotnet/PolyPersist.Net.DocumentStore.Tests/DocumentStoreTests.cs
@@ -81,5 +81,22 @@ namespace PolyPersist.Net.DocumentStore.Tests
             var exception = await Assert.ThrowsExceptionAsync<Exception>(async () => await store.DropCollection("notexist"));
             Assert.IsTrue(exception.Message.Contains("does not exist"));
         }
+
+        // PP-14: a failed Update must not leave the caller's entity with a new etag that was
+        // never persisted (it mutated etag/LastUpdate before the write).
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task DocumentStore_FailedUpdate_KeepsEtag(Func<string, Task<IDocumentStore>> factory)
+        {
+            var store = await factory(MethodBase.GetCurrentMethod().GetAsyncMethodName());
+            var col = await store.CreateCollection<SampleDocument>("etagcol");
+            var doc = new SampleDocument { PartitionKey = "pk", id = "a", str_value = "x" };
+            await col.Insert(doc);
+
+            doc.etag = "stale-etag"; // not the persisted etag -> the update must fail
+            await Assert.ThrowsExceptionAsync<Exception>(async () => await col.Update(doc));
+
+            Assert.AreEqual("stale-etag", doc.etag);
+        }
     }
 }

--- a/todo.txt
+++ b/todo.txt
@@ -35,7 +35,10 @@ errors. We go through these ONE BY ONE.
            guards double-commit and _committed is set only AFTER the commit actions succeed, so
            a failed commit still allows rollback. Test: Insert + failing AddCommitAction ->
            Commit throws -> Rollback still removes the insert.
-[ ] PP-14  Mongo Update mutates etag/LastUpdate BEFORE the write (not after success).
+[x] PP-14  Mongo Update mutated etag/LastUpdate BEFORE the write — DONE. If the write misses
+           (optimistic-concurrency / not found), the caller's entity was left with a new etag
+           that was never persisted. Now etag/LastUpdate are restored before throwing. Test
+           (Memory + real Mongo container): a failed Update keeps the original etag.
 [x] PP-15  Memory column Find/Delete ignored partitionKey — DONE. MapOfDocments is keyed by
            id alone; Find/Delete now also check the stored row.partitionKey matches the
            requested one (a matching id in another partition is not the row). Docker-free


### PR DESCRIPTION
`MongoDB_DocumentCollection.Update` mutated `document.etag`/`LastUpdate` **before** the write. On a missed write (optimistic-concurrency conflict / not found) it threw, but the caller's entity kept a brand-new etag that was never persisted — breaking retries, optimistic concurrency and rollback logic.

Now etag/LastUpdate are **restored before throwing**. Test (Memory + a real Mongo container): a failed Update keeps the original etag. 2 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)