### PR TITLE
PP-13 + PP-23: sync-Dispose deadlock guard, UtcNow consistency

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Memory/Memory_ColumnTable.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Memory/Memory_ColumnTable.cs
@@ -62,7 +62,7 @@ namespace PolyPersist.Net.ColumnStore.Memory
                 throw new Exception($"Row '{typeof(TRow).Name}' {row.id} can not be updated because it is already changed");
 
             row.etag = Guid.NewGuid().ToString();
-            row.LastUpdate = DateTime.Now;
+            row.LastUpdate = DateTime.UtcNow;
 
             data.etag = row.etag;
             data.Value = JsonSerializer.Serialize(row, typeof(TRow), JsonOptionsProvider.Options());

--- a/implementations/dotnet/src/PolyPersist.Net.DocumentStore.Memory/Memory_DocumentCollection.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.DocumentStore.Memory/Memory_DocumentCollection.cs
@@ -61,7 +61,7 @@ namespace PolyPersist.Net.DocumentStore.Memory
                 throw new Exception($"Document '{typeof(TDocument).Name}' {document.id} can not be updated because it is already changed");
 
             document.etag = Guid.NewGuid().ToString();
-            document.LastUpdate = DateTime.Now;
+            document.LastUpdate = DateTime.UtcNow;
 
             row.etag = document.etag;
             row.Value = JsonSerializer.Serialize(document, typeof(TDocument), JsonOptionsProvider.Options());

--- a/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.Transactions/Transaction.cs
@@ -497,8 +497,10 @@ namespace PolyPersist.Net.Transactions
             // Reason: ensures resources aren't leaked even if Dispose called synchronously.
             if (Volatile.Read(ref _committed) == 0 && _executedOperations.Any())
             {
-                // Blocking fallback: not recommended for I/O
-                (this as ITransaction).Rollback().GetAwaiter().GetResult();
+                // Blocking fallback (prefer `await using` / DisposeAsync). Offload to the
+                // thread pool so the async rollback does not capture a caller
+                // SynchronizationContext, which would deadlock this blocking wait.
+                Task.Run(async () => await (this as ITransaction).Rollback().ConfigureAwait(false)).GetAwaiter().GetResult();
             }
 
             GC.SuppressFinalize(this);

--- a/todo.txt
+++ b/todo.txt
@@ -57,10 +57,14 @@ errors. We go through these ONE BY ONE.
 [ ] PP-08  No ClickHouse implementation (analytics store).
 [ ] PP-09  No Redis / KeyValue implementation (cache store).
 [ ] PP-12  Entity-tracking key collisions ({TypeName}_{id} ignores partitionKey).
-[ ] PP-13  Dispose sync-over-async deadlock risk (Rollback().GetAwaiter().GetResult()).
+[x] PP-13  Dispose sync-over-async deadlock risk — DONE. The sync Dispose blocked on
+           Rollback().GetAwaiter().GetResult(); if the async rollback captured a caller
+           SynchronizationContext it could deadlock. Now offloaded via Task.Run so the
+           continuation never needs the calling thread. (Prefer `await using`/DisposeAsync.)
 [x] PP-22  Memory Document Delete ignored partitionKey — DONE. Find already checked it; Delete
            now also requires row.partitionKey to match. Docker-free test.
-[ ] PP-23  DateTime.Now vs UtcNow inconsistency (Memory Document/Column Update).
+[x] PP-23  DateTime.Now vs UtcNow — DONE. Memory Column/Document Update set LastUpdate with
+           DateTime.Now (local) while everything else uses UtcNow. Both switched to UtcNow.
 [ ] PP-24  Debug + copy-paste + wasteful ops (Console.WriteLine in Find hot path, etc.).
 [ ] PP-25  LINQ FROM without keyspace (QueryProvider uses `FROM {table}`).
 [ ] PP-26  Existence-check / metadata-update waste (S3 GetObjectAsync full download).


### PR DESCRIPTION
**PP-13:** synchronous `Dispose()` blocked on `Rollback().GetAwaiter().GetResult()`; if the async rollback captured a caller SynchronizationContext it could deadlock. Now offloaded via `Task.Run` so the continuation never needs the calling thread. (Prefer `await using`/DisposeAsync.)

**PP-23:** Memory column/document Update set `LastUpdate = DateTime.Now` (local) while everything else uses `UtcNow`. Both switched to `UtcNow`.

Builds 0/0. (No tests: PP-13 needs a deadlocking sync-context to exercise; PP-23 per request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)