### PR TITLE
PP-16 + PP-17: reject OR/!= in CQL; support Any/First

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_ExpressionVisitor.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_ExpressionVisitor.cs
@@ -98,10 +98,13 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
 
         protected override Expression VisitBinary(BinaryExpression node)
         {
-            if (node.NodeType == ExpressionType.AndAlso || node.NodeType == ExpressionType.OrElse)
+            if (node.NodeType == ExpressionType.OrElse)
+                throw new NotSupportedException("Cassandra CQL does not support 'OR' in a WHERE clause; split the query into separate queries instead.");
+
+            if (node.NodeType == ExpressionType.AndAlso)
             {
                 Visit(node.Left);
-                _conditions.Add(node.NodeType == ExpressionType.AndAlso ? "AND" : "OR");
+                _conditions.Add("AND");
                 Visit(node.Right);
                 return node;
             }
@@ -143,7 +146,7 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
             string opSymbol = node.NodeType switch
             {
                 ExpressionType.Equal => "=",
-                ExpressionType.NotEqual => "!=",
+                ExpressionType.NotEqual => throw new NotSupportedException("Cassandra CQL does not support '!=' in a WHERE clause."),
                 ExpressionType.GreaterThan => ">",
                 ExpressionType.GreaterThanOrEqual => ">=",
                 ExpressionType.LessThan => "<",
@@ -301,6 +304,25 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
                 {
                     throw new NotSupportedException("Only member expressions are supported in OrderBy/ThenBy clauses.");
                 }
+                Visit(node.Arguments[0]);
+                return node;
+            }
+
+            // .Any() with no predicate: we only need to know whether a row exists (LIMIT 1).
+            if (node.Method.Name == "Any" && node.Arguments.Count == 1)
+            {
+                _limit = 1;
+                Visit(node.Arguments[0]);
+                return node;
+            }
+
+            // .First()/.FirstOrDefault()/.Single()/.SingleOrDefault() with no predicate:
+            // fetch a single row (LIMIT 1). Use `.Where(...)` for filtering.
+            if ((node.Method.Name == "First" || node.Method.Name == "FirstOrDefault"
+                 || node.Method.Name == "Single" || node.Method.Name == "SingleOrDefault")
+                && node.Arguments.Count == 1)
+            {
+                _limit = 1;
                 Visit(node.Arguments[0]);
                 return node;
             }

--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_QueryProvider.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Linq/Cassandra_QueryProvider.cs
@@ -67,6 +67,10 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
             }
             else if (expression.Type == typeof(bool))
             {
+                // .Any(): true when the query returns at least one row
+                if (query.resultType == Cassandra_Query.ResultTypes.Count)
+                    return rs.First().GetValue<long>("count") > 0;
+                return rs.Any();
             }
             else if (typeof(IEnumerable).IsAssignableFrom(expression.Type))
             {
@@ -240,10 +244,39 @@ namespace PolyPersist.Net.ColumnStore.Cassandra.Linq
             }
             else
             {
-            }
+                // single-item result: .First()/.FirstOrDefault()/.Single()/.SingleOrDefault()
+                if (query.resultType == Cassandra_Query.ResultTypes.SelectRow)
+                    return _mapFirstRowToEntity(rs);
 
-            return null;
+                throw new NotSupportedException("Only a full-row single result (SELECT *) is supported here.");
+            }
         }
+
+        // maps the first row of the result set into a TRow (null when there is no row)
+        private TRow _mapFirstRowToEntity(RowSet rs)
+        {
+            var row = rs.FirstOrDefault();
+            if (row == null)
+                return default;
+
+            var accessors = MetadataHelper.GetAccessors<TRow>().ToDictionary(kvp => kvp.Key.ToLower(), kvp => kvp.Value);
+            var columns = rs.Columns;
+            var fieldIndexMap = new Dictionary<string, int>();
+            for (int i = 0; i < columns.Length; i++)
+                fieldIndexMap[columns[i].Name.ToLower()] = i;
+
+            var item = new TRow();
+            foreach (var accessor in accessors)
+            {
+                if (accessor.Value.Setter != null && fieldIndexMap.TryGetValue(accessor.Key, out int fieldIndex))
+                {
+                    var getter = Cassandra_Mapper.BuildTypedGetter(accessor.Value.Type);
+                    accessor.Value.Setter(item, getter(row, fieldIndex));
+                }
+            }
+            return item;
+        }
+
         public TResult Execute<TResult>(Expression expression) => (TResult)Execute(expression);
 
         //public async IAsyncEnumerable ExecuteAsync(Expression expression)

--- a/tests/dotnet/PolyPersist.Net.ColumnStore.Tests/ColumnStoreLinqTests.cs
+++ b/tests/dotnet/PolyPersist.Net.ColumnStore.Tests/ColumnStoreLinqTests.cs
@@ -368,5 +368,47 @@ namespace PolyPersist.Net.ColumnStore.Tests
             Assert.AreEqual(1, list.Count);
             Assert.AreEqual("s1", list[0].id);
         }
+
+        // PP-17: .Any() (bool branch) and .FirstOrDefault() (scalar branch) must return real
+        // values (they returned null). These are now supported via LIMIT 1.
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task ColumnStore_Linq_First_OK(Func<string, Task<IColumnStore>> factory)
+        {
+            var testName = MethodBase.GetCurrentMethod().GetAsyncMethodName().MakeStorageConformName();
+            var store = await factory(testName);
+            var table = await store.CreateTable<SampleRow>("sampletable");
+            await table.Insert(new SampleRow { PartitionKey = "pk", id = "q1", str_value = "A", int_value = 10 });
+
+            Assert.IsTrue(table.AsQueryable().Where(r => r.PartitionKey == "pk").Any());
+            Assert.IsFalse(table.AsQueryable().Where(r => r.PartitionKey == "nope").Any());
+
+            var first = table.AsQueryable().Where(r => r.PartitionKey == "pk").FirstOrDefault();
+            Assert.IsNotNull(first);
+            Assert.AreEqual("q1", first.id);
+            Assert.IsNull(table.AsQueryable().Where(r => r.PartitionKey == "nope").FirstOrDefault());
+        }
+
+        // PP-16: Cassandra CQL can't express != or OR in WHERE -> fail fast (the in-memory
+        // LINQ provider supports both, so only assert the throw for the Cassandra provider).
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task ColumnStore_Linq_CqlUnsupported_Throws(Func<string, Task<IColumnStore>> factory)
+        {
+            var testName = MethodBase.GetCurrentMethod().GetAsyncMethodName().MakeStorageConformName();
+            var store = await factory(testName);
+            var table = await store.CreateTable<SampleRow>("sampletable");
+            await table.Insert(new SampleRow { PartitionKey = "pk", id = "q1", str_value = "A", int_value = 10 });
+
+            if (store.ProviderName == "Cassandra")
+            {
+                Assert.ThrowsException<NotSupportedException>(() => table.AsQueryable().Where(r => r.str_value != "A").ToList());
+                Assert.ThrowsException<NotSupportedException>(() => table.AsQueryable().Where(r => r.str_value == "A" || r.int_value == 10).ToList());
+            }
+            else
+            {
+                table.AsQueryable().Where(r => r.str_value != "A").ToList(); // in-memory LINQ supports it
+            }
+        }
     }
 }

--- a/todo.txt
+++ b/todo.txt
@@ -44,8 +44,14 @@ errors. We go through these ONE BY ONE.
            requested one (a matching id in another partition is not the row). Docker-free
            tests: Find/Delete respect partitionKey. (Deeper: the id-only map still can't hold
            same-id-different-partition rows — related to PP-12, left for later.)
-[ ] PP-16  CQL WHERE: bare AND/OR, no `!=`, no parentheses.
-[ ] PP-17  LINQ scalar/bool branches return null (Cassandra_QueryProvider empty branches).
+[x] PP-16  CQL WHERE OR / != — DONE (fail-fast). The visitor generated invalid CQL for OR
+           and != (Cassandra can't express them). Both now throw a clear NotSupportedException.
+           (Parens are moot once OR is gone: AND-only is associative.) Cassandra-targeted test.
+[x] PP-17  LINQ scalar/bool branches returned null — DONE. The empty bool/scalar Execute
+           branches were also unreachable (the provider rejected .Any()/.First()). Added
+           .Any()/.First()/.FirstOrDefault()/.Single()/.SingleOrDefault() (no predicate) in the
+           visitor (LIMIT 1) + implemented the branches (bool -> rs.Any(); scalar -> map first
+           row). Verified against Scylla. (Partial PP-27 coverage.)
 [ ] PP-18  Blob (?): no partitionKey, no etag, truncation on write.
 [ ] PP-19  Blob object key = blob.id only (no partitionKey in key, no etag).
 [ ] PP-20  GridFS Delete can orphan chunks (deletes metadata doc first).


### PR DESCRIPTION
**PP-16:** the Cassandra LINQ visitor emitted invalid CQL for `||` (OR) and `!=` (Cassandra can't express them in WHERE). Both now **throw NotSupportedException** (fail fast). Parens moot once OR is gone.

**PP-17:** the bool/scalar Execute branches returned null and were unreachable (provider rejected `.Any()`/`.First()`). Added `.Any()/.First()/.FirstOrDefault()/.Single()/.SingleOrDefault()` (no predicate) in the visitor (LIMIT 1) + implemented the branches (bool → `rs.Any()`; single-row → map first row). Verified against Scylla.

Tests green on both Memory + Scylla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)