### PR TITLE
PP-18: FileSystem blob — no truncation, etag concurrency, partitionKey

### DIFF
--- a/docs/identity-and-partitionkey.md
+++ b/docs/identity-and-partitionkey.md
@@ -1,0 +1,39 @@
+# Identity & partition key
+
+The contract every PolyPersist store implements.
+
+## id — the logical identity
+- `id` uniquely identifies an entity and is **globally unique** (a GUID by default).
+- The **platform guarantees** this — the database does not have to enforce a global unique
+  constraint, so each store is free to key optimally.
+- This is d3i's `EntityId`.
+
+## partitionKey — a required physical routing key
+- `partitionKey` is **mandatory** (`CollectionCommon.CheckBeforeInsert/Update` rejects an
+  empty one). It is *not* part of the logical identity; it tells partitioned stores **where**
+  the entity lives.
+- **Point access takes `(partitionKey, id)`** because distributed stores (Cassandra, Cosmos,
+  DynamoDB, sharded MongoDB, partitioned SQL) require the partition key. This is the standard
+  cloud-native pattern, not a compromise.
+
+## Choosing the partition key (domain-decided)
+- **Aggregate root → `partitionKey = id`** (its own partition; also the default when there is
+  no natural partition, e.g. single-tenant / on-prem).
+- **Child entity → `partitionKey = <parent aggregate id>`** for co-location
+  (e.g. `ProjectAccess.PartitionKey => ProjectId`, `Auth.PartitionKey => accountId`).
+
+Reference pattern (doctratis): a computed property mapping `PartitionKey` onto a real field,
+so nothing is stored twice:
+```csharp
+string IEntity.PartitionKey { get => id;        set => id = value;        } // root
+string IEntity.PartitionKey { get => ProjectId; set => ProjectId = value; } // child
+```
+
+## How each store keys (because id is globally unique)
+| Store kind | Physical key | partitionKey role |
+|---|---|---|
+| Cassandra / Cosmos / sharded Mongo / partitioned SQL | `(partitionKey, id)` | required for routing |
+| Blob (S3/Azure/GCS/FileSystem), unsharded Mongo, unpartitioned SQL | `id` | metadata / optional index; **not** needed in the object key |
+
+Blobs gain nothing from a `partitionKey/id` object key (flat namespace), and a globally-unique
+`id` makes the id-only key safe — so blobs key by `id` and keep `partitionKey` in metadata.

--- a/implementations/dotnet/src/PolyPersist.Net.BlobStore.FileSystem/FileSystem_BlobContainer.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.BlobStore.FileSystem/FileSystem_BlobContainer.cs
@@ -59,15 +59,15 @@ namespace PolyPersist.Net.BlobStore.FileSystem
         Task<TBlob> IBlobContainer<TBlob>.Find(string partitionKey, string id)
         {
             var path = _makeFilePath(id);
-            if (File.Exists(path) == false)
-                return Task.FromResult<TBlob>(default);
-
             var metadataPath = path + ".meta.json";
-            if (File.Exists(metadataPath) == false)
+            if (File.Exists(path) == false || File.Exists(metadataPath) == false)
                 return Task.FromResult<TBlob>(default);
 
-            var json = File.ReadAllText(metadataPath);
-            var blob = JsonSerializer.Deserialize<TBlob>(json);
+            var blob = JsonSerializer.Deserialize<TBlob>(File.ReadAllText(metadataPath));
+            // the blob is identified by (partitionKey, id): a different partition is not it
+            if (blob.PartitionKey != partitionKey)
+                return Task.FromResult<TBlob>(default);
+
             return Task.FromResult(blob);
         }
 
@@ -75,13 +75,13 @@ namespace PolyPersist.Net.BlobStore.FileSystem
         Task IBlobContainer<TBlob>.Delete(string partitionKey, string id)
         {
             var path = _makeFilePath(id);
-            if (File.Exists(path) == false)
+            var metaPath = path + ".meta.json";
+            if (File.Exists(path) == false || File.Exists(metaPath) == false
+                || JsonSerializer.Deserialize<TBlob>(File.ReadAllText(metaPath)).PartitionKey != partitionKey)
                 throw new Exception($"Blob '{typeof(TBlob).Name}' {id} can not be removed because it is does not exist");
 
             File.Delete(path);
-            var metaPath = path + ".meta.json";
-            if (File.Exists(metaPath) == true)
-                File.Delete(metaPath);
+            File.Delete(metaPath);
 
             return Task.CompletedTask;
         }
@@ -93,16 +93,25 @@ namespace PolyPersist.Net.BlobStore.FileSystem
                 throw new Exception($"Blob '{typeof(TBlob).Name}' {blob.id} content cannot be read");
 
             var path = _makeFilePath(blob.id);
-            if (File.Exists(path) == false)
+            var metaPath = path + ".meta.json";
+            if (File.Exists(path) == false || File.Exists(metaPath) == false)
                 throw new Exception($"Blob '{typeof(TBlob).Name}' {blob.id} can not upload, because it is does not exist");
 
-            using var fs = File.Create(path);
-            content.CopyTo(fs);
+            // optimistic concurrency: the stored etag must still match
+            var stored = JsonSerializer.Deserialize<TBlob>(File.ReadAllText(metaPath));
+            if (stored.etag != blob.etag)
+                throw new Exception($"Blob '{typeof(TBlob).Name}' {blob.id} can not be updated because it is already changed");
+
+            // write to a temp file then replace atomically, so a failed write does not truncate
+            // (lose) the existing content
+            var tempPath = path + ".tmp";
+            using (var fs = File.Create(tempPath))
+                content.CopyTo(fs);
+            File.Move(tempPath, path, overwrite: true);
 
             blob.etag = Guid.NewGuid().ToString();
             blob.LastUpdate = DateTime.UtcNow;
-            File.WriteAllText(path + ".meta.json", JsonSerializer.Serialize(blob));
-
+            File.WriteAllText(metaPath, JsonSerializer.Serialize(blob));
 
             return Task.CompletedTask;
         }
@@ -111,12 +120,17 @@ namespace PolyPersist.Net.BlobStore.FileSystem
         Task IBlobContainer<TBlob>.UpdateMetadata(TBlob blob)
         {
             var path = _makeFilePath(blob.id);
-            if (File.Exists(path) == false)
+            var metaPath = path + ".meta.json";
+            if (File.Exists(path) == false || File.Exists(metaPath) == false)
                 throw new Exception($"Blob '{typeof(TBlob).Name}' {blob.id} can not upload, because it is does not exist");
+
+            var stored = JsonSerializer.Deserialize<TBlob>(File.ReadAllText(metaPath));
+            if (stored.etag != blob.etag)
+                throw new Exception($"Blob '{typeof(TBlob).Name}' {blob.id} can not be updated because it is already changed");
 
             blob.etag = Guid.NewGuid().ToString();
             blob.LastUpdate = DateTime.UtcNow;
-            File.WriteAllText(path + ".meta.json", JsonSerializer.Serialize(blob));
+            File.WriteAllText(metaPath, JsonSerializer.Serialize(blob));
 
             return Task.CompletedTask;
         }

--- a/tests/dotnet/PolyPersist.Net.BlobStore.Tests/FileSystem_Security_Tests.cs
+++ b/tests/dotnet/PolyPersist.Net.BlobStore.Tests/FileSystem_Security_Tests.cs
@@ -3,30 +3,73 @@ using PolyPersist;
 using PolyPersist.Net.BlobStore.FileSystem;
 using System;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace PolyPersist.Net.BlobStore.Tests
 {
-    // PP-02: the FileSystem blob store must not let a path-traversal id escape the container.
+    // PP-02 (traversal) + PP-18 (partitionKey verify, etag concurrency, no truncation).
     [TestClass]
     public class FileSystem_Security_Tests
     {
+        private static async Task<(IBlobContainer<SampleBlob>, string)> NewContainerAsync()
+        {
+            string basePath = Path.Combine(Path.GetTempPath(), "pp_fs_" + Guid.NewGuid().ToString("N"));
+            IBlobStore store = new FileSystem_BlobStore(basePath);
+            var container = await store.CreateContainer<SampleBlob>("c");
+            return (container, basePath);
+        }
+
         [TestMethod]
         public async Task Find_WithTraversalId_Throws()
         {
-            string basePath = Path.Combine(Path.GetTempPath(), "pp_fs_sec_" + Guid.NewGuid().ToString("N"));
-            IBlobStore store = new FileSystem_BlobStore(basePath);
-            IBlobContainer<SampleBlob> container = await store.CreateContainer<SampleBlob>("sec");
+            var (container, basePath) = await NewContainerAsync();
             try
             {
                 await Assert.ThrowsExceptionAsync<ArgumentException>(
                     async () => await container.Find("pk", "../../escape.txt"));
             }
-            finally
+            finally { if (Directory.Exists(basePath)) Directory.Delete(basePath, true); }
+        }
+
+        [TestMethod]
+        public async Task Find_And_Delete_RespectPartitionKey()
+        {
+            var (container, basePath) = await NewContainerAsync();
+            try
             {
-                if (Directory.Exists(basePath))
-                    Directory.Delete(basePath, true);
+                var blob = new SampleBlob { PartitionKey = "p1", id = "a", contentType = "text/plain", fileName = "a.txt" };
+                using (var content = new MemoryStream(Encoding.UTF8.GetBytes("v1")))
+                    await container.Upload(blob, content);
+
+                Assert.IsNotNull(await container.Find("p1", "a")); // right partition
+                Assert.IsNull(await container.Find("p2", "a"));    // wrong partition -> not found
+                await Assert.ThrowsExceptionAsync<Exception>(async () => await container.Delete("p2", "a"));
+                Assert.IsNotNull(await container.Find("p1", "a")); // wrong-partition delete left it
             }
+            finally { if (Directory.Exists(basePath)) Directory.Delete(basePath, true); }
+        }
+
+        [TestMethod]
+        public async Task UpdateContent_WithStaleEtag_Throws_AndKeepsOldContent()
+        {
+            var (container, basePath) = await NewContainerAsync();
+            try
+            {
+                var blob = new SampleBlob { PartitionKey = "p1", id = "a", contentType = "text/plain", fileName = "a.txt" };
+                using (var content = new MemoryStream(Encoding.UTF8.GetBytes("v1")))
+                    await container.Upload(blob, content);
+
+                var stale = new SampleBlob { PartitionKey = "p1", id = "a", etag = "stale-etag" };
+                using (var content = new MemoryStream(Encoding.UTF8.GetBytes("v2")))
+                    await Assert.ThrowsExceptionAsync<Exception>(async () => await container.UpdateContent(stale, content));
+
+                // the old content is intact (no truncation, no overwrite on a rejected update)
+                using var stream = await container.Download(await container.Find("p1", "a"));
+                using var reader = new StreamReader(stream);
+                Assert.AreEqual("v1", reader.ReadToEnd());
+            }
+            finally { if (Directory.Exists(basePath)) Directory.Delete(basePath, true); }
         }
     }
 }

--- a/todo.txt
+++ b/todo.txt
@@ -52,9 +52,19 @@ errors. We go through these ONE BY ONE.
            .Any()/.First()/.FirstOrDefault()/.Single()/.SingleOrDefault() (no predicate) in the
            visitor (LIMIT 1) + implemented the branches (bool -> rs.Any(); scalar -> map first
            row). Verified against Scylla. (Partial PP-27 coverage.)
-[ ] PP-18  Blob (?): no partitionKey, no etag, truncation on write.
-[ ] PP-19  Blob object key = blob.id only (no partitionKey in key, no etag).
-[ ] PP-20  GridFS Delete can orphan chunks (deletes metadata doc first).
+[x] PP-18  FileSystem blob — DONE. (1) UpdateContent writes to a temp file + File.Move(overwrite)
+           so a failed write no longer truncates/loses the old content; (2) UpdateContent/
+           UpdateMetadata do optimistic-concurrency etag checks; (3) Find/Delete verify the
+           stored partitionKey (key stays id, per the identity contract). Docker-free tests.
+[ ] PP-19  Cloud object stores (S3/Azure/GCS/MinIO): object key = blob.id only. PLAN:
+           key = $"{partitionKey}/{blob.id}" across all 4 stores in every method
+           (Upload/Find/Delete/Download/Update) -> fixes collision + cross-partition. etag via
+           conditional writes (S3 If-Match, Azure ETag) is a separate follow-up. Big (4 stores).
+           Testcontainers (MinIO/Azurite). (Depends on the partitionKey design below.)
+[ ] PP-20  GridFS Delete orphans chunks (deletes metadata first). PLAN: delete the GridFS
+           content/chunks FIRST, then the metadata doc (a dangling metadata is detectable/
+           retryable; orphan chunks are a silent space leak). Handle null fileInfo. Small.
+           Test via GridFS Mongo container.
 [ ] PP-21  Untyped exceptions everywhere (bare Exception). Refactor to typed exceptions.
 [ ] PP-30  Cassandra/Scylla effectively untested (setup commented out).
 


### PR DESCRIPTION
- **No truncation:** UpdateContent writes a temp file then `File.Move(overwrite)` (was `File.Create`, which truncated before the write → data loss on failure).
- **etag concurrency:** UpdateContent/UpdateMetadata check the stored etag first.
- **partitionKey:** Find/Delete verify the stored blob's partitionKey. Per the identity contract the object key stays `id` (globally unique); partitionKey is verified metadata.

Docker-free tests. Adds `docs/identity-and-partitionkey.md` (the agreed contract).