### PR TITLE
PP-20: GridFS Delete removes chunks before metadata

### DIFF
--- a/implementations/dotnet/src/PolyPersist.Net.BlobStore.GridFS/GridFS_BlobContainer.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.BlobStore.GridFS/GridFS_BlobContainer.cs
@@ -67,18 +67,22 @@ namespace PolyPersist.Net.BlobStore.GridFS
         /// <inheritdoc/>
         async Task IBlobContainer<TBlob>.Delete(string partitionKey, string id)
         {
+            // Delete the GridFS content (chunks) BEFORE the metadata document. If the metadata
+            // were deleted first and the chunk delete then failed (or the file was missing), the
+            // chunks would be orphaned (a silent space leak; no cross-collection transaction).
+            // This order leaves at worst a dangling metadata row, which is detectable/retryable.
+            GridFSFileInfo fileInfo = await _getFileInfo(partitionKey, id).ConfigureAwait(false);
+            if (fileInfo == null)
+                throw new Exception($"Blob '{typeof(TBlob).Name}' {id} can not be removed because it is does not exist");
+
+            await _gridFSBucket.DeleteAsync(fileInfo.Id).ConfigureAwait(false);
+
             DeleteResult result = await _metadataCollection.DeleteOneAsync(e => e.id == id && e.PartitionKey == partitionKey).ConfigureAwait(false);
             if (result.IsAcknowledged == false)
                 throw new Exception($"Blob '{typeof(TBlob).Name}' {id} can not be removed. Database refused to acknowledge the operation.");
 
             if (result.DeletedCount != 1)
                 throw new Exception($"Blob '{typeof(TBlob).Name}' {id} can not be removed because it is does not exist");
-
-            GridFSFileInfo fileInfo = await _getFileInfo(partitionKey, id).ConfigureAwait(false);
-            if (fileInfo == null)
-                throw new Exception($"Blob '{typeof(TBlob).Name}' {id} cannot be deleted: it does not exist.");
-
-            await _gridFSBucket.DeleteAsync(fileInfo.Id).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/todo.txt
+++ b/todo.txt
@@ -61,10 +61,10 @@ errors. We go through these ONE BY ONE.
            (Upload/Find/Delete/Download/Update) -> fixes collision + cross-partition. etag via
            conditional writes (S3 If-Match, Azure ETag) is a separate follow-up. Big (4 stores).
            Testcontainers (MinIO/Azurite). (Depends on the partitionKey design below.)
-[ ] PP-20  GridFS Delete orphans chunks (deletes metadata first). PLAN: delete the GridFS
-           content/chunks FIRST, then the metadata doc (a dangling metadata is detectable/
-           retryable; orphan chunks are a silent space leak). Handle null fileInfo. Small.
-           Test via GridFS Mongo container.
+[x] PP-20  GridFS Delete orphaned chunks — DONE. Now deletes the GridFS content/chunks FIRST
+           (via _getFileInfo), then the metadata doc, so a failure can't leave orphan chunks
+           (at worst a dangling metadata, which is detectable/retryable). Verified: GridFS
+           delete tests pass against the Mongo container.
 [ ] PP-21  Untyped exceptions everywhere (bare Exception). Refactor to typed exceptions.
 [ ] PP-30  Cassandra/Scylla effectively untested (setup commented out).
 


### PR DESCRIPTION
Delete removed the metadata doc first and the chunks second, so a failed chunk delete left **orphan chunks** (silent space leak). Now it deletes the GridFS content (chunks) **first**, then the metadata — at worst a dangling metadata (detectable/retryable), never orphan chunks. GridFS delete tests pass against the Mongo container.