### PR TITLE
Implement the event store: Dapper (SQL), Memory, Cassandra, EventStoreDB

### DIFF
--- a/implementations/dotnet/PolyPersist.Net.sln
+++ b/implementations/dotnet/PolyPersist.Net.sln
@@ -68,6 +68,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.RelationalS
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.RelationalStore.Tests", "..\..\tests\dotnet\PolyPersist.Net.RelationalStore.Tests\PolyPersist.Net.RelationalStore.Tests.csproj", "{617A771A-7393-45F3-BC39-8B40E39198A8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.Dapper", "src\PolyPersist.Net.EventStore.Dapper\PolyPersist.Net.EventStore.Dapper.csproj", "{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.Tests", "..\..\tests\dotnet\PolyPersist.Net.EventStore.Tests\PolyPersist.Net.EventStore.Tests.csproj", "{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +82,30 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Release|x64.Build.0 = Release|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Release|x86.Build.0 = Release|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Debug|x64.Build.0 = Debug|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Release|x64.ActiveCfg = Release|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Release|x64.Build.0 = Release|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}.Release|x86.Build.0 = Release|Any CPU
 		{2C23F2F2-51F1-4B7B-BC29-BF85C091E00C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2C23F2F2-51F1-4B7B-BC29-BF85C091E00C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2C23F2F2-51F1-4B7B-BC29-BF85C091E00C}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/implementations/dotnet/PolyPersist.Net.sln
+++ b/implementations/dotnet/PolyPersist.Net.sln
@@ -76,6 +76,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.Cassandra", "src\PolyPersist.Net.EventStore.Cassandra\PolyPersist.Net.EventStore.Cassandra.csproj", "{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.EventStoreDB", "src\PolyPersist.Net.EventStore.EventStoreDB\PolyPersist.Net.EventStore.EventStoreDB.csproj", "{F83677C5-E960-4B2D-9E8E-94483E81074D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,18 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Debug|x64.Build.0 = Debug|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Release|x64.ActiveCfg = Release|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Release|x64.Build.0 = Release|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F83677C5-E960-4B2D-9E8E-94483E81074D}.Release|x86.Build.0 = Release|Any CPU
 		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/implementations/dotnet/PolyPersist.Net.sln
+++ b/implementations/dotnet/PolyPersist.Net.sln
@@ -72,6 +72,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.Tests", "..\..\tests\dotnet\PolyPersist.Net.EventStore.Tests\PolyPersist.Net.EventStore.Tests.csproj", "{0C5EC196-F9D0-4D01-8CBC-62F45DC3FBEE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.Memory", "src\PolyPersist.Net.EventStore.Memory\PolyPersist.Net.EventStore.Memory.csproj", "{165FC1AC-4E7F-4335-A145-26BF677807AA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolyPersist.Net.EventStore.Cassandra", "src\PolyPersist.Net.EventStore.Cassandra\PolyPersist.Net.EventStore.Cassandra.csproj", "{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +86,30 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|x64.Build.0 = Debug|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Debug|x86.Build.0 = Debug|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Release|x64.ActiveCfg = Release|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Release|x64.Build.0 = Release|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{FF97720C-D08D-4AA7-BF71-C9B6B85007CA}.Release|x86.Build.0 = Release|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Release|x64.Build.0 = Release|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{165FC1AC-4E7F-4335-A145-26BF677807AA}.Release|x86.Build.0 = Release|Any CPU
 		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8784B2E-5EA7-4D0C-BE83-D0300E3EA8BB}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.Cassandra/Cassandra_EventStore.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.Cassandra/Cassandra_EventStore.cs
@@ -1,0 +1,190 @@
+using Cassandra;
+using PolyPersist.Net.Core;
+
+namespace PolyPersist.Net.EventStore.Cassandra
+{
+    /// <summary>
+    /// Append-only event/stream store on Cassandra/Scylla. A stream is a partition (streamid), events
+    /// are clustered by version ascending, so per-stream ordering and the (streamid, version) uniqueness
+    /// come from the primary key. Optimistic concurrency uses a read-guard for clear messages plus an
+    /// <c>INSERT ... IF NOT EXISTS</c> (LWT) as the ultimate guard against races.
+    /// </summary>
+    public class Cassandra_EventStore : IEventStore
+    {
+        private const int Any = -2;
+        private const int NoStream = -1;
+
+        private readonly ISession _session;
+        private readonly string _keyspace;
+        private readonly string _table;
+        private int _ensured;
+
+        public Cassandra_EventStore(string connectionString, string tableName = "events")
+        {
+            var cfg = _Parse(connectionString);
+            var cluster = Cluster.Builder()
+                .AddContactPoint(cfg.Host)
+                .WithPort(cfg.Port)
+                .WithCredentials(cfg.Username, cfg.Password)
+                .Build();
+
+            _session = cluster.Connect(cfg.Keyspace);
+            _keyspace = cfg.Keyspace;
+            _table = tableName;
+        }
+
+        /// <inheritdoc/>
+        IStore.StorageModels IStore.StorageModel => IStore.StorageModels.EventStore;
+        /// <inheritdoc/>
+        string IStore.ProviderName => "EventStore.Cassandra";
+
+        private async Task _EnsureTableAsync()
+        {
+            if (Volatile.Read(ref _ensured) == 1)
+                return;
+
+            await _session.ExecuteAsync(new SimpleStatement(
+                $@"CREATE TABLE IF NOT EXISTS {_keyspace}.{_table} (
+                    streamid text,
+                    version int,
+                    eventid text,
+                    eventtype text,
+                    data text,
+                    metadata text,
+                    timestamp timestamp,
+                    PRIMARY KEY (streamid, version)
+                ) WITH CLUSTERING ORDER BY (version ASC)")).ConfigureAwait(false);
+
+            Volatile.Write(ref _ensured, 1);
+        }
+
+        private async Task<int> _CurrentVersionAsync(string streamId)
+        {
+            var rs = await _session.ExecuteAsync(new SimpleStatement(
+                $"SELECT MAX(version) AS m FROM {_keyspace}.{_table} WHERE streamid = ?", streamId)).ConfigureAwait(false);
+            var row = rs.FirstOrDefault();
+            int? v = row?.GetValue<int?>("m");
+            return v ?? NoStream;
+        }
+
+        private static void _Guard(string streamId, int expectedVersion, int currentVersion)
+        {
+            if (expectedVersion == Any)
+                return;
+            if (expectedVersion == NoStream && currentVersion != NoStream)
+                throw new Exception($"Concurrency conflict: stream '{streamId}' already exists (version {currentVersion})");
+            if (expectedVersion >= 0 && currentVersion != expectedVersion)
+                throw new Exception($"Concurrency conflict: stream '{streamId}' expected version {expectedVersion} but was {currentVersion}");
+        }
+
+        /// <inheritdoc/>
+        async Task<int> IEventStore.AppendToStream(string streamId, int expectedVersion, IList<IEvent> events)
+        {
+            await _EnsureTableAsync().ConfigureAwait(false);
+
+            int current = await _CurrentVersionAsync(streamId).ConfigureAwait(false);
+            _Guard(streamId, expectedVersion, current);
+
+            int version = current;
+            foreach (var e in events)
+            {
+                version++;
+                e.streamId = streamId;
+                e.version = version;
+                if (string.IsNullOrEmpty(e.eventId) == true)
+                    e.eventId = Guid.NewGuid().ToString();
+                if (e.timestamp == default)
+                    e.timestamp = DateTime.UtcNow;
+
+                var ts = new DateTimeOffset(DateTime.SpecifyKind(e.timestamp, DateTimeKind.Utc));
+                var rs = await _session.ExecuteAsync(new SimpleStatement(
+                    $@"INSERT INTO {_keyspace}.{_table} (streamid,version,eventid,eventtype,data,metadata,timestamp)
+                       VALUES (?,?,?,?,?,?,?) IF NOT EXISTS",
+                    e.streamId, e.version, e.eventId, e.eventType, e.data, e.metadata, ts)).ConfigureAwait(false);
+
+                bool applied = rs.FirstOrDefault()?.GetValue<bool>("[applied]") ?? true;
+                if (applied == false)
+                    throw new Exception($"Concurrency conflict: stream '{streamId}' version {version} already exists");
+            }
+
+            return version;
+        }
+
+        /// <inheritdoc/>
+        async Task<IList<IEvent>> IEventStore.ReadStream(string streamId, int fromVersion, int maxCount)
+        {
+            await _EnsureTableAsync().ConfigureAwait(false);
+
+            string cql = $"SELECT streamid,version,eventid,eventtype,data,metadata,timestamp FROM {_keyspace}.{_table} WHERE streamid = ? AND version >= ?";
+            if (maxCount >= 0)
+                cql += $" LIMIT {maxCount}";
+
+            var rs = await _session.ExecuteAsync(new SimpleStatement(cql, streamId, fromVersion)).ConfigureAwait(false);
+
+            var list = new List<IEvent>();
+            foreach (var row in rs)
+            {
+                list.Add(new Event
+                {
+                    streamId = row.GetValue<string>("streamid"),
+                    version = row.GetValue<int>("version"),
+                    eventId = row.GetValue<string>("eventid"),
+                    eventType = row.GetValue<string>("eventtype"),
+                    data = row.GetValue<string>("data"),
+                    metadata = row.GetValue<string>("metadata"),
+                    timestamp = row.GetValue<DateTimeOffset>("timestamp").UtcDateTime,
+                });
+            }
+            return list;
+        }
+
+        /// <inheritdoc/>
+        async Task<bool> IEventStore.StreamExists(string streamId)
+        {
+            await _EnsureTableAsync().ConfigureAwait(false);
+            var rs = await _session.ExecuteAsync(new SimpleStatement(
+                $"SELECT streamid FROM {_keyspace}.{_table} WHERE streamid = ? LIMIT 1", streamId)).ConfigureAwait(false);
+            return rs.Any();
+        }
+
+        /// <inheritdoc/>
+        async Task<int> IEventStore.GetStreamVersion(string streamId)
+        {
+            await _EnsureTableAsync().ConfigureAwait(false);
+            return await _CurrentVersionAsync(streamId).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        async Task IEventStore.DeleteStream(string streamId, int expectedVersion)
+        {
+            await _EnsureTableAsync().ConfigureAwait(false);
+            int current = await _CurrentVersionAsync(streamId).ConfigureAwait(false);
+            _Guard(streamId, expectedVersion, current);
+
+            await _session.ExecuteAsync(new SimpleStatement(
+                $"DELETE FROM {_keyspace}.{_table} WHERE streamid = ?", streamId)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        object IEventStore.GetUnderlyingImplementation() => _session;
+
+        private record struct _Conn(string Host, int Port, string Username, string Password, string Keyspace);
+
+        private static _Conn _Parse(string connectionString)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var part in connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kv = part.Split('=', 2);
+                if (kv.Length == 2)
+                    dict[kv[0].Trim()] = kv[1].Trim();
+            }
+            dict.TryGetValue("host", out var host);
+            dict.TryGetValue("port", out var port);
+            dict.TryGetValue("username", out var username);
+            dict.TryGetValue("password", out var password);
+            dict.TryGetValue("keyspace", out var keyspace);
+            return new _Conn(host, int.TryParse(port, out var p) ? p : 9042, username, password, keyspace);
+        }
+    }
+}

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.Cassandra/PolyPersist.Net.EventStore.Cassandra.csproj
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.Cassandra/PolyPersist.Net.EventStore.Cassandra.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
+  </ItemGroup>
+</Project>

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.Dapper/Dapper_EventStore.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.Dapper/Dapper_EventStore.cs
@@ -1,0 +1,178 @@
+using System.Data.Common;
+using Dapper;
+using Microsoft.Data.Sqlite;
+using Npgsql;
+using PolyPersist.Net.Core;
+
+namespace PolyPersist.Net.EventStore.Dapper
+{
+    /// <summary>
+    /// Append-only, immutable event/stream store on a SQL backend, using pure Dapper (no LINQ needed:
+    /// the surface is append + read-by-stream). A single <c>events</c> table with a composite primary
+    /// key <c>(streamId, version)</c> gives optimistic concurrency for free (a duplicate version is a
+    /// conflict). Works on SQLite and PostgreSQL; the provider is chosen at construction.
+    ///
+    /// Event sourcing and audit are both just events on streams (the store does not distinguish them).
+    /// Subscriptions/projections are provider-specific and reached via GetUnderlyingImplementation().
+    /// </summary>
+    public class Dapper_EventStore : IEventStore
+    {
+        private readonly string _provider;
+        private readonly string _connectionString;
+        private readonly string _table;
+        private int _ensured;
+
+        // Sentinels for expectedVersion (mirror the contract).
+        private const int Any = -2;
+        private const int NoStream = -1;
+
+        /// <param name="provider">"SQLite.MS" or "PostgreSQL".</param>
+        /// <param name="connectionString">the ADO.NET connection string for that provider.</param>
+        /// <param name="tableName">the events table name (default "events").</param>
+        public Dapper_EventStore(string provider, string connectionString, string tableName = "events")
+        {
+            _provider = provider;
+            _connectionString = connectionString;
+            _table = tableName;
+        }
+
+        /// <inheritdoc/>
+        IStore.StorageModels IStore.StorageModel => IStore.StorageModels.EventStore;
+        /// <inheritdoc/>
+        string IStore.ProviderName => $"EventStore.Dapper({_provider})";
+
+        private DbConnection _NewConnection() => _provider switch
+        {
+            "SQLite.MS" or "SQLite" or "Sqlite" => new SqliteConnection(_connectionString),
+            "PostgreSQL" or "Postgres" or "Npgsql" => new NpgsqlConnection(_connectionString),
+            _ => throw new NotSupportedException($"Unsupported event-store provider '{_provider}'")
+        };
+
+        private async Task<DbConnection> _OpenAsync()
+        {
+            var conn = _NewConnection();
+            await conn.OpenAsync().ConfigureAwait(false);
+            await _EnsureTableAsync(conn).ConfigureAwait(false);
+            return conn;
+        }
+
+        private async Task _EnsureTableAsync(DbConnection conn)
+        {
+            if (Volatile.Read(ref _ensured) == 1)
+                return;
+
+            string ddl = $@"CREATE TABLE IF NOT EXISTS ""{_table}"" (
+    ""streamId""  TEXT NOT NULL,
+    ""version""   INTEGER NOT NULL,
+    ""eventId""   TEXT,
+    ""eventType"" TEXT,
+    ""data""      TEXT,
+    ""metadata""  TEXT,
+    ""timestamp"" TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (""streamId"", ""version"")
+)";
+            await conn.ExecuteAsync(ddl).ConfigureAwait(false);
+            Volatile.Write(ref _ensured, 1);
+        }
+
+        private async Task<int> _CurrentVersionAsync(DbConnection conn, string streamId, DbTransaction tx = null)
+        {
+            long? max = await conn.ExecuteScalarAsync<long?>(
+                $@"SELECT MAX(""version"") FROM ""{_table}"" WHERE ""streamId"" = @s",
+                new { s = streamId }, tx).ConfigureAwait(false);
+            return max.HasValue ? (int)max.Value : NoStream;
+        }
+
+        private static void _GuardExpectedVersion(string streamId, int expectedVersion, int currentVersion)
+        {
+            if (expectedVersion == Any)
+                return;
+            if (expectedVersion == NoStream && currentVersion != NoStream)
+                throw new Exception($"Concurrency conflict: stream '{streamId}' already exists (version {currentVersion})");
+            if (expectedVersion >= 0 && currentVersion != expectedVersion)
+                throw new Exception($"Concurrency conflict: stream '{streamId}' expected version {expectedVersion} but was {currentVersion}");
+        }
+
+        /// <inheritdoc/>
+        async Task<int> IEventStore.AppendToStream(string streamId, int expectedVersion, IList<IEvent> events)
+        {
+            using var conn = await _OpenAsync().ConfigureAwait(false);
+            using var tx = await conn.BeginTransactionAsync().ConfigureAwait(false);
+
+            int current = await _CurrentVersionAsync(conn, streamId, tx as DbTransaction).ConfigureAwait(false);
+            _GuardExpectedVersion(streamId, expectedVersion, current);
+
+            int version = current;
+            foreach (var e in events)
+            {
+                version++;
+                e.streamId = streamId;
+                e.version = version;
+                if (string.IsNullOrEmpty(e.eventId) == true)
+                    e.eventId = Guid.NewGuid().ToString();
+                if (e.timestamp == default)
+                    e.timestamp = DateTime.UtcNow;
+
+                await conn.ExecuteAsync(
+                    $@"INSERT INTO ""{_table}"" (""streamId"",""version"",""eventId"",""eventType"",""data"",""metadata"",""timestamp"")
+                       VALUES (@streamId,@version,@eventId,@eventType,@data,@metadata,@timestamp)",
+                    new { e.streamId, e.version, e.eventId, e.eventType, e.data, e.metadata, e.timestamp },
+                    tx as DbTransaction).ConfigureAwait(false);
+            }
+
+            await tx.CommitAsync().ConfigureAwait(false);
+            return version;
+        }
+
+        /// <inheritdoc/>
+        async Task<IList<IEvent>> IEventStore.ReadStream(string streamId, int fromVersion, int maxCount)
+        {
+            using var conn = await _OpenAsync().ConfigureAwait(false);
+            string limit = maxCount >= 0 ? $" LIMIT {maxCount}" : string.Empty;
+
+            var rows = await conn.QueryAsync<Event>(
+                $@"SELECT ""streamId"",""version"",""eventId"",""eventType"",""data"",""metadata"",""timestamp""
+                   FROM ""{_table}"" WHERE ""streamId"" = @s AND ""version"" >= @from ORDER BY ""version""{limit}",
+                new { s = streamId, from = fromVersion }).ConfigureAwait(false);
+
+            return rows.Cast<IEvent>().ToList();
+        }
+
+        /// <inheritdoc/>
+        async Task<bool> IEventStore.StreamExists(string streamId)
+        {
+            using var conn = await _OpenAsync().ConfigureAwait(false);
+            long? one = await conn.ExecuteScalarAsync<long?>(
+                $@"SELECT 1 FROM ""{_table}"" WHERE ""streamId"" = @s LIMIT 1",
+                new { s = streamId }).ConfigureAwait(false);
+            return one.HasValue;
+        }
+
+        /// <inheritdoc/>
+        async Task<int> IEventStore.GetStreamVersion(string streamId)
+        {
+            using var conn = await _OpenAsync().ConfigureAwait(false);
+            return await _CurrentVersionAsync(conn, streamId).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        async Task IEventStore.DeleteStream(string streamId, int expectedVersion)
+        {
+            using var conn = await _OpenAsync().ConfigureAwait(false);
+            int current = await _CurrentVersionAsync(conn, streamId).ConfigureAwait(false);
+            _GuardExpectedVersion(streamId, expectedVersion, current);
+
+            await conn.ExecuteAsync(
+                $@"DELETE FROM ""{_table}"" WHERE ""streamId"" = @s",
+                new { s = streamId }).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        object IEventStore.GetUnderlyingImplementation()
+        {
+            // A fresh (unopened) ADO connection for provider-specific use (raw SQL, polling-based
+            // subscriptions, ...). The caller opens and disposes it.
+            return _NewConnection();
+        }
+    }
+}

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.Dapper/PolyPersist.Net.EventStore.Dapper.csproj
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.Dapper/PolyPersist.Net.EventStore.Dapper.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageReference Include="Npgsql" Version="8.0.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
+  </ItemGroup>
+</Project>

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.EventStoreDB/EventStoreDB_EventStore.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.EventStoreDB/EventStoreDB_EventStore.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using EventStore.Client;
+using PolyPersist.Net.Core;
+
+namespace PolyPersist.Net.EventStore.EventStoreDB
+{
+    /// <summary>
+    /// Append-only event/stream store on EventStoreDB (native gRPC client). Streams, revisions and
+    /// optimistic concurrency (expected revision) are first-class in the engine, so the contract maps
+    /// almost directly. Subscriptions/projections are reached via GetUnderlyingImplementation()
+    /// (the native EventStoreClient).
+    /// </summary>
+    public class EventStoreDB_EventStore : IEventStore
+    {
+        private const int Any = -2;
+        private const int NoStream = -1;
+
+        private readonly EventStoreClient _client;
+
+        public EventStoreDB_EventStore(string connectionString)
+        {
+            var settings = EventStoreClientSettings.Create(connectionString);
+            _client = new EventStoreClient(settings);
+        }
+
+        /// <inheritdoc/>
+        IStore.StorageModels IStore.StorageModel => IStore.StorageModels.EventStore;
+        /// <inheritdoc/>
+        string IStore.ProviderName => "EventStore.EventStoreDB";
+
+        /// <inheritdoc/>
+        async Task<int> IEventStore.AppendToStream(string streamId, int expectedVersion, IList<IEvent> events)
+        {
+            var payload = new List<EventData>();
+            foreach (var e in events)
+            {
+                e.streamId = streamId;
+                if (string.IsNullOrEmpty(e.eventId) == true || Guid.TryParse(e.eventId, out _) == false)
+                    e.eventId = Guid.NewGuid().ToString();
+                if (e.timestamp == default)
+                    e.timestamp = DateTime.UtcNow;
+
+                ReadOnlyMemory<byte>? meta = string.IsNullOrEmpty(e.metadata)
+                    ? null
+                    : Encoding.UTF8.GetBytes(e.metadata);
+
+                payload.Add(new EventData(
+                    Uuid.FromGuid(Guid.Parse(e.eventId)),
+                    string.IsNullOrEmpty(e.eventType) ? "event" : e.eventType,
+                    Encoding.UTF8.GetBytes(e.data ?? string.Empty),
+                    meta));
+            }
+
+            try
+            {
+                IWriteResult result = expectedVersion switch
+                {
+                    Any => await _client.AppendToStreamAsync(streamId, StreamState.Any, payload).ConfigureAwait(false),
+                    NoStream => await _client.AppendToStreamAsync(streamId, StreamState.NoStream, payload).ConfigureAwait(false),
+                    _ => await _client.AppendToStreamAsync(streamId, StreamRevision.FromInt64(expectedVersion), payload).ConfigureAwait(false),
+                };
+                return (int)result.NextExpectedStreamRevision.ToInt64();
+            }
+            catch (WrongExpectedVersionException)
+            {
+                if (expectedVersion == NoStream)
+                    throw new Exception($"Concurrency conflict: stream '{streamId}' already exists");
+                throw new Exception($"Concurrency conflict: stream '{streamId}' expected version {expectedVersion}");
+            }
+        }
+
+        /// <inheritdoc/>
+        async Task<IList<IEvent>> IEventStore.ReadStream(string streamId, int fromVersion, int maxCount)
+        {
+            long count = maxCount >= 0 ? maxCount : long.MaxValue;
+            var result = _client.ReadStreamAsync(Direction.Forwards, streamId, StreamPosition.FromInt64(fromVersion), count);
+
+            if (await result.ReadState.ConfigureAwait(false) == ReadState.StreamNotFound)
+                return [];
+
+            var list = new List<IEvent>();
+            await foreach (var resolved in result.ConfigureAwait(false))
+            {
+                var ev = resolved.Event;
+                list.Add(new Event
+                {
+                    streamId = streamId,
+                    version = (int)ev.EventNumber.ToInt64(),
+                    eventId = ev.EventId.ToString(),
+                    eventType = ev.EventType,
+                    data = Encoding.UTF8.GetString(ev.Data.ToArray()),
+                    metadata = ev.Metadata.Length > 0 ? Encoding.UTF8.GetString(ev.Metadata.ToArray()) : null,
+                    timestamp = ev.Created,
+                });
+            }
+            return list;
+        }
+
+        /// <inheritdoc/>
+        async Task<bool> IEventStore.StreamExists(string streamId)
+        {
+            var result = _client.ReadStreamAsync(Direction.Forwards, streamId, StreamPosition.Start, 1);
+            return await result.ReadState.ConfigureAwait(false) != ReadState.StreamNotFound;
+        }
+
+        /// <inheritdoc/>
+        async Task<int> IEventStore.GetStreamVersion(string streamId)
+        {
+            var result = _client.ReadStreamAsync(Direction.Backwards, streamId, StreamPosition.End, 1);
+            if (await result.ReadState.ConfigureAwait(false) == ReadState.StreamNotFound)
+                return NoStream;
+
+            await foreach (var resolved in result.ConfigureAwait(false))
+                return (int)resolved.Event.EventNumber.ToInt64();
+
+            return NoStream;
+        }
+
+        /// <inheritdoc/>
+        async Task IEventStore.DeleteStream(string streamId, int expectedVersion)
+        {
+            try
+            {
+                _ = expectedVersion switch
+                {
+                    Any => await _client.DeleteAsync(streamId, StreamState.Any).ConfigureAwait(false),
+                    NoStream => await _client.DeleteAsync(streamId, StreamState.NoStream).ConfigureAwait(false),
+                    _ => await _client.DeleteAsync(streamId, StreamRevision.FromInt64(expectedVersion)).ConfigureAwait(false),
+                };
+            }
+            catch (WrongExpectedVersionException)
+            {
+                throw new Exception($"Concurrency conflict: stream '{streamId}' expected version {expectedVersion}");
+            }
+        }
+
+        /// <inheritdoc/>
+        object IEventStore.GetUnderlyingImplementation() => _client;
+    }
+}

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.EventStoreDB/PolyPersist.Net.EventStore.EventStoreDB.csproj
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.EventStoreDB/PolyPersist.Net.EventStore.EventStoreDB.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
+  </ItemGroup>
+</Project>

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.Memory/Memory_EventStore.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.Memory/Memory_EventStore.cs
@@ -1,0 +1,132 @@
+using PolyPersist.Net.Core;
+
+namespace PolyPersist.Net.EventStore.Memory
+{
+    /// <summary>
+    /// In-process append-only event/stream store. Not durable - for tests and for consumers' unit
+    /// tests of event-sourced aggregates without a database. Stores copies of events so external
+    /// mutation cannot corrupt stored state (mirrors the persistence semantics of the real stores).
+    /// </summary>
+    public class Memory_EventStore : IEventStore
+    {
+        private const int Any = -2;
+        private const int NoStream = -1;
+
+        private readonly Dictionary<string, List<IEvent>> _streams = [];
+        private readonly object _lock = new();
+
+        public Memory_EventStore(string connectionString = null)
+        {
+        }
+
+        /// <inheritdoc/>
+        IStore.StorageModels IStore.StorageModel => IStore.StorageModels.EventStore;
+        /// <inheritdoc/>
+        string IStore.ProviderName => "EventStore.Memory";
+
+        private static IEvent _Clone(IEvent e) => new Event
+        {
+            eventId = e.eventId,
+            streamId = e.streamId,
+            version = e.version,
+            eventType = e.eventType,
+            data = e.data,
+            metadata = e.metadata,
+            timestamp = e.timestamp,
+        };
+
+        private static void _Guard(string streamId, int expectedVersion, int currentVersion)
+        {
+            if (expectedVersion == Any)
+                return;
+            if (expectedVersion == NoStream && currentVersion != NoStream)
+                throw new Exception($"Concurrency conflict: stream '{streamId}' already exists (version {currentVersion})");
+            if (expectedVersion >= 0 && currentVersion != expectedVersion)
+                throw new Exception($"Concurrency conflict: stream '{streamId}' expected version {expectedVersion} but was {currentVersion}");
+        }
+
+        /// <inheritdoc/>
+        Task<int> IEventStore.AppendToStream(string streamId, int expectedVersion, IList<IEvent> events)
+        {
+            lock (_lock)
+            {
+                _streams.TryGetValue(streamId, out var list);
+                int current = (list?.Count ?? 0) - 1;
+                _Guard(streamId, expectedVersion, current);
+
+                if (list == null)
+                {
+                    list = [];
+                    _streams[streamId] = list;
+                }
+
+                int version = current;
+                foreach (var e in events)
+                {
+                    version++;
+                    e.streamId = streamId;
+                    e.version = version;
+                    if (string.IsNullOrEmpty(e.eventId) == true)
+                        e.eventId = Guid.NewGuid().ToString();
+                    if (e.timestamp == default)
+                        e.timestamp = DateTime.UtcNow;
+
+                    list.Add(_Clone(e));
+                }
+
+                return Task.FromResult(version);
+            }
+        }
+
+        /// <inheritdoc/>
+        Task<IList<IEvent>> IEventStore.ReadStream(string streamId, int fromVersion, int maxCount)
+        {
+            lock (_lock)
+            {
+                if (_streams.TryGetValue(streamId, out var list) == false)
+                    return Task.FromResult<IList<IEvent>>([]);
+
+                IEnumerable<IEvent> query = list.Where(e => e.version >= fromVersion);
+                if (maxCount >= 0)
+                    query = query.Take(maxCount);
+
+                return Task.FromResult<IList<IEvent>>(query.Select(_Clone).ToList());
+            }
+        }
+
+        /// <inheritdoc/>
+        Task<bool> IEventStore.StreamExists(string streamId)
+        {
+            lock (_lock)
+                return Task.FromResult(_streams.TryGetValue(streamId, out var list) && list.Count > 0);
+        }
+
+        /// <inheritdoc/>
+        Task<int> IEventStore.GetStreamVersion(string streamId)
+        {
+            lock (_lock)
+                return Task.FromResult(_streams.TryGetValue(streamId, out var list) ? list.Count - 1 : NoStream);
+        }
+
+        /// <inheritdoc/>
+        Task IEventStore.DeleteStream(string streamId, int expectedVersion)
+        {
+            lock (_lock)
+            {
+                _streams.TryGetValue(streamId, out var list);
+                int current = (list?.Count ?? 0) - 1;
+                _Guard(streamId, expectedVersion, current);
+
+                _streams.Remove(streamId);
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <inheritdoc/>
+        object IEventStore.GetUnderlyingImplementation()
+        {
+            lock (_lock)
+                return _streams;
+        }
+    }
+}

--- a/implementations/dotnet/src/PolyPersist.Net.EventStore.Memory/PolyPersist.Net.EventStore.Memory.csproj
+++ b/implementations/dotnet/src/PolyPersist.Net.EventStore.Memory/PolyPersist.Net.EventStore.Memory.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
+  </ItemGroup>
+</Project>

--- a/interfaces/dotnet/PolyPersist/Core/Event.cs
+++ b/interfaces/dotnet/PolyPersist/Core/Event.cs
@@ -1,0 +1,18 @@
+namespace PolyPersist.Net.Core
+{
+    /// <summary>
+    /// Concrete, instantiable <see cref="IEvent"/> for callers (event-sourced aggregates, audit) to
+    /// create events, and for stores to materialise them on read. The counterpart of
+    /// <see cref="Entity"/> for <see cref="IEntity"/>.
+    /// </summary>
+    public class Event : IEvent
+    {
+        public string eventId { get; set; }
+        public string streamId { get; set; }
+        public int version { get; set; }
+        public string eventType { get; set; }
+        public string data { get; set; }
+        public string metadata { get; set; }
+        public DateTime timestamp { get; set; }
+    }
+}

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/EventStoreTests.cs
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/EventStoreTests.cs
@@ -276,10 +276,17 @@ namespace PolyPersist.Net.EventStore.Tests
             var stream = TestMain.NewStreamId();
             await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"), Ev("B", "2")));
 
-            using var conn = (DbConnection)store.GetUnderlyingImplementation();
-            await conn.OpenAsync();
-            long count = await conn.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM \"{table}\" WHERE \"streamId\" = @s", new { s = stream });
-            Assert.AreEqual(2L, count);
+            var underlying = store.GetUnderlyingImplementation();
+            Assert.IsNotNull(underlying);
+
+            // The escape hatch is backend-specific: only the SQL backends expose a DbConnection.
+            if (underlying is DbConnection conn)
+            {
+                await conn.OpenAsync();
+                long count = await conn.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM \"{table}\" WHERE \"streamId\" = @s", new { s = stream });
+                Assert.AreEqual(2L, count);
+                conn.Dispose();
+            }
         }
     }
 }

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/EventStoreTests.cs
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/EventStoreTests.cs
@@ -1,0 +1,285 @@
+using System.Data.Common;
+using Dapper;
+using PolyPersist.Net.Core;
+
+namespace PolyPersist.Net.EventStore.Tests
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class EventStoreTests
+    {
+        private const int Any = -2;
+        private const int NoStream = -1;
+
+        private static async Task<IEventStore> NewStore(Func<string, Task<IEventStore>> factory)
+            => await factory(TestMain.NewTableName());
+
+        private static IEvent Ev(string type, string data, string metadata = null)
+            => new Event { eventType = type, data = data, metadata = metadata };
+
+        private static List<IEvent> Evs(params IEvent[] e) => new(e);
+
+        // ---- store basics ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task StorageModel_Is_EventStore(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            Assert.AreEqual(IStore.StorageModels.EventStore, ((IStore)store).StorageModel);
+            Assert.IsFalse(string.IsNullOrEmpty(((IStore)store).ProviderName));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task StreamExists_And_Version_ForNewStream(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+
+            Assert.IsFalse(await store.StreamExists(stream));
+            Assert.AreEqual(NoStream, await store.GetStreamVersion(stream));
+        }
+
+        // ---- append + read ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_Then_Read_Roundtrip(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+
+            int last = await store.AppendToStream(stream, NoStream, Evs(
+                Ev("Created", "{\"n\":1}"),
+                Ev("Updated", "{\"n\":2}"),
+                Ev("Closed", "{\"n\":3}")));
+
+            Assert.AreEqual(2, last);                    // 0-based last version
+            Assert.IsTrue(await store.StreamExists(stream));
+            Assert.AreEqual(2, await store.GetStreamVersion(stream));
+
+            var read = await store.ReadStream(stream, 0, -1);
+            Assert.AreEqual(3, read.Count);
+            Assert.AreEqual("Created", read[0].eventType);
+            Assert.AreEqual(0, read[0].version);
+            Assert.AreEqual("Updated", read[1].eventType);
+            Assert.AreEqual(1, read[1].version);
+            Assert.AreEqual("Closed", read[2].eventType);
+            Assert.AreEqual(2, read[2].version);
+            Assert.AreEqual(stream, read[0].streamId);
+            Assert.AreEqual("{\"n\":1}", read[0].data);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_Assigns_EventId_And_Timestamp(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+
+            await store.AppendToStream(stream, NoStream, Evs(Ev("E", "d")));
+            var read = await store.ReadStream(stream, 0, -1);
+
+            Assert.IsFalse(string.IsNullOrEmpty(read[0].eventId));
+            Assert.AreNotEqual(default, read[0].timestamp);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_Preserves_Metadata(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+
+            await store.AppendToStream(stream, NoStream, Evs(Ev("E", "d", "{\"user\":\"alice\"}")));
+            var read = await store.ReadStream(stream, 0, -1);
+            Assert.AreEqual("{\"user\":\"alice\"}", read[0].metadata);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_MultipleCalls_ContiguousVersions(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+
+            int last0 = await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1")));
+            Assert.AreEqual(0, last0);
+            int last1 = await store.AppendToStream(stream, 0, Evs(Ev("B", "2"), Ev("C", "3")));
+            Assert.AreEqual(2, last1);
+
+            var read = await store.ReadStream(stream, 0, -1);
+            CollectionAssert.AreEqual(new[] { 0, 1, 2 }, read.Select(e => e.version).ToArray());
+            CollectionAssert.AreEqual(new[] { "A", "B", "C" }, read.Select(e => e.eventType).ToArray());
+        }
+
+        // ---- optimistic concurrency ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_NoStream_ToExistingStream_Throws(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1")));
+
+            var ex = await Assert.ThrowsExceptionAsync<Exception>(
+                () => store.AppendToStream(stream, NoStream, Evs(Ev("B", "2"))));
+            Assert.IsTrue(ex.Message.Contains("already exists"));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_WrongExpectedVersion_Throws(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"), Ev("B", "2"))); // last = 1
+
+            var ex = await Assert.ThrowsExceptionAsync<Exception>(
+                () => store.AppendToStream(stream, 0, Evs(Ev("C", "3")))); // expected 0, but is 1
+            Assert.IsTrue(ex.Message.Contains("expected version"));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_CorrectExpectedVersion_Ok(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1")));       // last = 0
+            int last = await store.AppendToStream(stream, 0, Evs(Ev("B", "2")));   // expected 0 -> ok
+            Assert.AreEqual(1, last);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Append_Any_AlwaysAppends(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, Any, Evs(Ev("A", "1")));
+            int last = await store.AppendToStream(stream, Any, Evs(Ev("B", "2")));
+            Assert.AreEqual(1, last);
+            Assert.AreEqual(2, (await store.ReadStream(stream, 0, -1)).Count);
+        }
+
+        // ---- read variants ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task ReadStream_FromVersion_Skips_Earlier(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"), Ev("B", "2"), Ev("C", "3")));
+
+            var read = await store.ReadStream(stream, 1, -1);
+            CollectionAssert.AreEqual(new[] { 1, 2 }, read.Select(e => e.version).ToArray());
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task ReadStream_MaxCount_Limits(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"), Ev("B", "2"), Ev("C", "3")));
+
+            var read = await store.ReadStream(stream, 0, 2);
+            Assert.AreEqual(2, read.Count);
+            Assert.AreEqual(0, read[0].version);
+            Assert.AreEqual(1, read[1].version);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task ReadStream_Nonexistent_ReturnsEmpty(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var read = await store.ReadStream(TestMain.NewStreamId(), 0, -1);
+            Assert.AreEqual(0, read.Count);
+        }
+
+        // ---- delete ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task DeleteStream_Removes_Stream(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"), Ev("B", "2")));
+
+            await store.DeleteStream(stream, Any);
+            Assert.IsFalse(await store.StreamExists(stream));
+            Assert.AreEqual(0, (await store.ReadStream(stream, 0, -1)).Count);
+            Assert.AreEqual(NoStream, await store.GetStreamVersion(stream));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task DeleteStream_WrongExpectedVersion_Throws(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"))); // last = 0
+
+            var ex = await Assert.ThrowsExceptionAsync<Exception>(() => store.DeleteStream(stream, 5));
+            Assert.IsTrue(ex.Message.Contains("expected version"));
+        }
+
+        // ---- isolation + model-vs-use ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task Streams_Are_Isolated(Func<string, Task<IEventStore>> factory)
+        {
+            var store = await NewStore(factory);
+            var s1 = TestMain.NewStreamId();
+            var s2 = TestMain.NewStreamId();
+
+            await store.AppendToStream(s1, NoStream, Evs(Ev("A", "1")));
+            await store.AppendToStream(s2, NoStream, Evs(Ev("B", "2"), Ev("C", "3")));
+
+            Assert.AreEqual(0, await store.GetStreamVersion(s1));
+            Assert.AreEqual(1, await store.GetStreamVersion(s2));
+            Assert.AreEqual(1, (await store.ReadStream(s1, 0, -1)).Count);
+            Assert.AreEqual(2, (await store.ReadStream(s2, 0, -1)).Count);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task DomainAndAudit_Streams_Coexist(Func<string, Task<IEventStore>> factory)
+        {
+            // one event store serves BOTH event sourcing (domain) and audit - just different streams.
+            var store = await NewStore(factory);
+            var order = "order-" + Guid.NewGuid().ToString("N");
+            var audit = "audit-" + Guid.NewGuid().ToString("N");
+
+            await store.AppendToStream(order, NoStream, Evs(Ev("OrderPlaced", "{}")));
+            await store.AppendToStream(audit, NoStream, Evs(Ev("Login", "{}"), Ev("PasswordChanged", "{}")));
+
+            Assert.AreEqual("OrderPlaced", (await store.ReadStream(order, 0, -1)).Single().eventType);
+            Assert.AreEqual(2, (await store.ReadStream(audit, 0, -1)).Count);
+        }
+
+        // ---- escape hatch ----
+
+        [DataTestMethod]
+        [DynamicData(nameof(TestMain.StoreInstances), typeof(TestMain), DynamicDataSourceType.Property)]
+        public async Task GetUnderlyingImplementation_RawSql_Ok(Func<string, Task<IEventStore>> factory)
+        {
+            var table = TestMain.NewTableName();
+            var store = await factory(table);
+            var stream = TestMain.NewStreamId();
+            await store.AppendToStream(stream, NoStream, Evs(Ev("A", "1"), Ev("B", "2")));
+
+            using var conn = (DbConnection)store.GetUnderlyingImplementation();
+            await conn.OpenAsync();
+            long count = await conn.ExecuteScalarAsync<long>($"SELECT COUNT(*) FROM \"{table}\" WHERE \"streamId\" = @s", new { s = stream });
+            Assert.AreEqual(2L, count);
+        }
+    }
+}

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/PolyPersist.Net.EventStore.Tests.csproj
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/PolyPersist.Net.EventStore.Tests.csproj
@@ -15,10 +15,13 @@
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Dapper\PolyPersist.Net.EventStore.Dapper.csproj" />
+    <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Memory\PolyPersist.Net.EventStore.Memory.csproj" />
+    <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Cassandra\PolyPersist.Net.EventStore.Cassandra.csproj" />
     <ProjectReference Include="..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
     <ProjectReference Include="..\PolyPersist.Net.Test\PolyPersist.Net.Test.csproj" />
   </ItemGroup>

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/PolyPersist.Net.EventStore.Tests.csproj
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/PolyPersist.Net.EventStore.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Dapper\PolyPersist.Net.EventStore.Dapper.csproj" />
+    <ProjectReference Include="..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
+    <ProjectReference Include="..\PolyPersist.Net.Test\PolyPersist.Net.Test.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/PolyPersist.Net.EventStore.Tests.csproj
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/PolyPersist.Net.EventStore.Tests.csproj
@@ -16,12 +16,14 @@
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
     <PackageReference Include="CassandraCSharpDriver" Version="3.22.0" />
+    <PackageReference Include="Testcontainers.EventStoreDb" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Dapper\PolyPersist.Net.EventStore.Dapper.csproj" />
     <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Memory\PolyPersist.Net.EventStore.Memory.csproj" />
     <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.Cassandra\PolyPersist.Net.EventStore.Cassandra.csproj" />
+    <ProjectReference Include="..\..\..\implementations\dotnet\src\PolyPersist.Net.EventStore.EventStoreDB\PolyPersist.Net.EventStore.EventStoreDB.csproj" />
     <ProjectReference Include="..\..\..\interfaces\dotnet\PolyPersist\PolyPersist.Net.csproj" />
     <ProjectReference Include="..\PolyPersist.Net.Test\PolyPersist.Net.Test.csproj" />
   </ItemGroup>

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/TestMain.cs
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/TestMain.cs
@@ -1,4 +1,9 @@
+using Cassandra;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using PolyPersist.Net.EventStore.Cassandra;
 using PolyPersist.Net.EventStore.Dapper;
+using PolyPersist.Net.EventStore.Memory;
 using PolyPersist.Net.Test;
 using Testcontainers.PostgreSql;
 
@@ -21,8 +26,16 @@ namespace PolyPersist.Net.EventStore.Tests
 
         static TestMain()
         {
+            _Setup_Memory();
             _Setup_Sqlite();
             _Setup_Postgres();
+            _Setup_Scylla();
+        }
+
+        private static void _Setup_Memory()
+        {
+            Func<string, Task<IEventStore>> factory = _ => Task.FromResult<IEventStore>(new Memory_EventStore());
+            StoreInstances.Add([factory]);
         }
 
         public static string NewTableName() => ("t" + Guid.NewGuid().ToString("N")).MakeStorageConformName();
@@ -77,6 +90,56 @@ namespace PolyPersist.Net.EventStore.Tests
             }
         }
 
+        private static IContainer _scylla;
+        private static readonly SemaphoreSlim _scyllaLock = new(1, 1);
+
+        private static void _Setup_Scylla()
+        {
+            Func<string, Task<IEventStore>> factory = async keyspace =>
+            {
+                await _EnsureScylla().ConfigureAwait(false);
+
+                var host = _scylla.Hostname;
+                var port = _scylla.GetMappedPublicPort(9042);
+
+                var cluster = Cluster.Builder().AddContactPoint(host).WithPort(port)
+                    .WithCredentials("cassandra", "cassandra").Build();
+                using (var session = await cluster.ConnectAsync().ConfigureAwait(false))
+                    await session.ExecuteAsync(new SimpleStatement(
+                        $"CREATE KEYSPACE IF NOT EXISTS {keyspace} WITH replication = {{'class':'SimpleStrategy','replication_factor':1}}")).ConfigureAwait(false);
+
+                return new Cassandra_EventStore($"host={host};port={port};username=cassandra;password=cassandra;keyspace={keyspace}");
+            };
+            StoreInstances.Add([factory]);
+        }
+
+        private static async Task _EnsureScylla()
+        {
+            if (_scylla != null)
+                return;
+
+            await _scyllaLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_scylla != null)
+                    return;
+
+                var container = new ContainerBuilder()
+                    .WithImage("scylladb/scylla:5.4")
+                    .WithCleanUp(true)
+                    .WithPortBinding(9042, assignRandomHostPort: true)
+                    .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(9042))
+                    .Build();
+
+                await container.StartAsync().ConfigureAwait(false);
+                _scylla = container;
+            }
+            finally
+            {
+                _scyllaLock.Release();
+            }
+        }
+
         [AssemblyInitialize]
         public static Task AssemblyInit(TestContext _) => Task.CompletedTask;
 
@@ -85,6 +148,8 @@ namespace PolyPersist.Net.EventStore.Tests
         {
             if (_pg != null)
                 await _pg.DisposeAsync().ConfigureAwait(false);
+            if (_scylla != null)
+                await _scylla.DisposeAsync().ConfigureAwait(false);
 
             lock (_sqliteFiles)
             {

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/TestMain.cs
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/TestMain.cs
@@ -1,0 +1,103 @@
+using PolyPersist.Net.EventStore.Dapper;
+using PolyPersist.Net.Test;
+using Testcontainers.PostgreSql;
+
+namespace PolyPersist.Net.EventStore.Tests
+{
+    /// <summary>
+    /// Registers the event-store backends the tests run against. The factory argument is a unique
+    /// events-table name (per test) so tests are isolated even on the shared PostgreSQL container.
+    /// - SQLite: an isolated temp-file database per store (always available, no Docker).
+    /// - PostgreSQL: a single Testcontainer, started lazily on first use.
+    /// </summary>
+    [TestClass]
+    public static class TestMain
+    {
+        public static List<object[]> StoreInstances { get; } = [];
+
+        private static readonly List<string> _sqliteFiles = [];
+        private static PostgreSqlContainer _pg;
+        private static readonly SemaphoreSlim _pgLock = new(1, 1);
+
+        static TestMain()
+        {
+            _Setup_Sqlite();
+            _Setup_Postgres();
+        }
+
+        public static string NewTableName() => ("t" + Guid.NewGuid().ToString("N")).MakeStorageConformName();
+        public static string NewStreamId() => "stream-" + Guid.NewGuid().ToString("N");
+
+        private static void _Setup_Sqlite()
+        {
+            Func<string, Task<IEventStore>> factory = tableName =>
+            {
+                string file = Path.Combine(Path.GetTempPath(), $"pp_es_{Guid.NewGuid():N}.db");
+                lock (_sqliteFiles)
+                    _sqliteFiles.Add(file);
+
+                IEventStore store = new Dapper_EventStore("SQLite.MS", $"Data Source={file}", tableName);
+                return Task.FromResult(store);
+            };
+            StoreInstances.Add([factory]);
+        }
+
+        private static void _Setup_Postgres()
+        {
+            Func<string, Task<IEventStore>> factory = async tableName =>
+            {
+                await _EnsurePostgres().ConfigureAwait(false);
+                return new Dapper_EventStore("PostgreSQL", _pg.GetConnectionString(), tableName);
+            };
+            StoreInstances.Add([factory]);
+        }
+
+        private static async Task _EnsurePostgres()
+        {
+            if (_pg != null)
+                return;
+
+            await _pgLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_pg != null)
+                    return;
+
+                var container = new PostgreSqlBuilder()
+                    .WithImage("postgres:16-alpine")
+                    .WithCleanUp(true)
+                    .Build();
+
+                await container.StartAsync().ConfigureAwait(false);
+                _pg = container;
+            }
+            finally
+            {
+                _pgLock.Release();
+            }
+        }
+
+        [AssemblyInitialize]
+        public static Task AssemblyInit(TestContext _) => Task.CompletedTask;
+
+        [AssemblyCleanup]
+        public static async Task Cleanup()
+        {
+            if (_pg != null)
+                await _pg.DisposeAsync().ConfigureAwait(false);
+
+            lock (_sqliteFiles)
+            {
+                foreach (var file in _sqliteFiles)
+                {
+                    try
+                    {
+                        if (File.Exists(file))
+                            File.Delete(file);
+                    }
+                    catch { /* best-effort temp cleanup */ }
+                }
+            }
+        }
+    }
+}

--- a/tests/dotnet/PolyPersist.Net.EventStore.Tests/TestMain.cs
+++ b/tests/dotnet/PolyPersist.Net.EventStore.Tests/TestMain.cs
@@ -3,8 +3,10 @@ using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using PolyPersist.Net.EventStore.Cassandra;
 using PolyPersist.Net.EventStore.Dapper;
+using PolyPersist.Net.EventStore.EventStoreDB;
 using PolyPersist.Net.EventStore.Memory;
 using PolyPersist.Net.Test;
+using Testcontainers.EventStoreDb;
 using Testcontainers.PostgreSql;
 
 namespace PolyPersist.Net.EventStore.Tests
@@ -30,6 +32,41 @@ namespace PolyPersist.Net.EventStore.Tests
             _Setup_Sqlite();
             _Setup_Postgres();
             _Setup_Scylla();
+            _Setup_EventStoreDB();
+        }
+
+        private static EventStoreDbContainer _esdb;
+        private static readonly SemaphoreSlim _esdbLock = new(1, 1);
+
+        private static void _Setup_EventStoreDB()
+        {
+            Func<string, Task<IEventStore>> factory = async _ =>
+            {
+                await _EnsureEsdb().ConfigureAwait(false);
+                return new EventStoreDB_EventStore(_esdb.GetConnectionString());
+            };
+            StoreInstances.Add([factory]);
+        }
+
+        private static async Task _EnsureEsdb()
+        {
+            if (_esdb != null)
+                return;
+
+            await _esdbLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_esdb != null)
+                    return;
+
+                var container = new EventStoreDbBuilder().WithCleanUp(true).Build();
+                await container.StartAsync().ConfigureAwait(false);
+                _esdb = container;
+            }
+            finally
+            {
+                _esdbLock.Release();
+            }
         }
 
         private static void _Setup_Memory()
@@ -150,6 +187,8 @@ namespace PolyPersist.Net.EventStore.Tests
                 await _pg.DisposeAsync().ConfigureAwait(false);
             if (_scylla != null)
                 await _scylla.DisposeAsync().ConfigureAwait(false);
+            if (_esdb != null)
+                await _esdb.DisposeAsync().ConfigureAwait(false);
 
             lock (_sqliteFiles)
             {


### PR DESCRIPTION
## Summary
Implements the full **event store** family behind the `IEventStore` / `IEvent` contract — an append-only, immutable stream store that serves both **event sourcing** and **audit** (they are just events on different streams).

Adds a concrete `Core/Event.cs` (instantiable `IEvent`, the counterpart of `Entity`).

## Implementations (impl-per-backend, flavor-suffixed)
| Project | Backend | Notes |
|---|---|---|
| `EventStore.Dapper` | SQLite + PostgreSQL | one `events` table, composite PK `(streamId, version)` = free optimistic concurrency; pure Dapper |
| `EventStore.Memory` | in-process | for tests / event-sourcing unit tests; stores copies |
| `EventStore.Cassandra` | Cassandra / Scylla | partition = streamid, clustering = version; `INSERT … IF NOT EXISTS` (LWT) + read-guard |
| `EventStore.EventStoreDB` | EventStoreDB | native gRPC client; StreamState/StreamRevision expected-version; soft-delete |

## Tests
One shared, backend-agnostic `PolyPersist.Net.EventStore.Tests` (MSTest): **18 contract-level methods run data-driven over all five backends** (Memory + SQLite + PostgreSQL + Scylla + EventStoreDB via Testcontainers) = **90 tests green**. Covers append/read roundtrip, version assignment, eventId/timestamp/metadata, multi-append contiguity, optimistic concurrency (NoStream/exact/Any), read from-version/maxCount/empty, delete + guard, stream isolation, domain+audit coexistence, and the escape hatch.

Contract semantics (expectedVersion sentinels, error messages, versions) are identical across all backends. Solution builds 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
