### PR TITLE
Adopt query<T>; remove leaky store-level join root

### DIFF
--- a/contracts/AnalyticalStore.contract
+++ b/contracts/AnalyticalStore.contract
@@ -34,11 +34,6 @@ namespace PolyPersist {
 
         # Drops an existing fact table.
         async method DropTable(tableName: string)
-
-        # ANALYTICAL query root spanning multiple tables (star-schema joins, cross-fact aggregation).
-        # Deliberately NOT portable to non-relational stores; the return value is generic - in .NET
-        # the linq2db DataConnection over which LINQ (and raw SQL) queries are written.
-        method Query() => any
     }
 
     # IAnalyticalTable represents a single fact table. Writing is BATCH-first (bulk append); there is
@@ -56,10 +51,9 @@ namespace PolyPersist {
         # for batched ingestion, so callers should accumulate rows and append them together.
         async method InsertBatch(records: list[TRecord])
 
-        # Single-table analytical query (aggregation / GROUP BY / scan).
-        # The return value is generic: in .NET an IQueryable<T> (linq2db -> dialect SQL). For raw SQL
-        # use GetUnderlyingImplementation.
-        method Query<T constraint TRecord instantiable>() => any
+        # Single-table analytical query (aggregation / GROUP BY / scan). Language-mapped:
+        # .NET IQueryable<TRecord>, Java Stream<TRecord>, ...
+        method Query() => query<TRecord>
 
         # Getting the underlying implementation.
         # Please use this method carefully, because the returned value is different in every

--- a/contracts/RelationalStore.contract
+++ b/contracts/RelationalStore.contract
@@ -45,17 +45,12 @@ namespace PolyPersist {
         #
         # @param tableName - The name of the table to be dropped.
         async method DropTable(tableName: string)
-
-        # RELATIONAL-ONLY query root for joins / multi-table / set-based SELECTs.
-        # This is deliberately NOT portable to document/column stores, therefore it lives on the
-        # relational store only. The return value is generic (in .NET the linq2db DataConnection,
-        # over which LINQ joins are written; the same handle also serves raw SQL via Dapper).
-        method Query() => any
     }
 
     # ITable defines CRUD and single-table query operations on a relational table.
     # This surface IS portable: it mirrors IDocumentCollection / IColumnTable, so cross-store code
-    # keeps working. Joins are NOT here (they are not portable) - use IRelationalStore.Query().
+    # keeps working. Query() returns the language-native queryable (LINQ in .NET); joins are written
+    # in the host language over these queryables (advanced multi-table access via GetUnderlyingImplementation).
     interface ITable<TRecord constraint IRecord instantiable> {
 
         # Read-only property for parent Store.
@@ -79,10 +74,8 @@ namespace PolyPersist {
         # Returns the row if found, or null if not found.
         async method Find(partitionKey: string, id: string) => TRecord
 
-        # Portable, SINGLE-TABLE query interface (filter / project / order).
-        # The return value is generic, so the implementation can define the real type:
-        # in .NET an IQueryable<T>, in Java a Stream / Querydsl, etc.
-        method Query<T constraint TRecord instantiable>() => any
+        # Portable, single-table query. Language-mapped: .NET IQueryable<TRecord>, Java Stream<TRecord>, ...
+        method Query() => query<TRecord>
 
         # Getting the underlying implementation.
         # Please use this method carefully, because the returned value is different in every

--- a/implementations/dotnet/src/PolyPersist.Net.RelationalStore.Dapper/Relational_Store.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.RelationalStore.Dapper/Relational_Store.cs
@@ -102,14 +102,6 @@ namespace PolyPersist.Net.RelationalStore.Dapper
             await db.ExecuteAsync($"DROP TABLE \"{tableName}\"").ConfigureAwait(false);
         }
 
-        /// <inheritdoc/>
-        object IRelationalStore.Query()
-        {
-            // Relational-only join / multi-table root. The caller owns the returned DataConnection
-            // (write LINQ joins on it, or BeginTransaction for a native ACID unit of work) and
-            // disposes it.
-            return CreateConnection();
-        }
     }
 
     // Internal bridge so the (non-class-constrained) store can trigger DDL on a table whose

--- a/implementations/dotnet/src/PolyPersist.Net.RelationalStore.Dapper/Relational_Table.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.RelationalStore.Dapper/Relational_Table.cs
@@ -120,23 +120,13 @@ namespace PolyPersist.Net.RelationalStore.Dapper
         }
 
         /// <inheritdoc/>
-        object ITable<TRecord>.Query<T>()
-        {
-            // T is only known as `T : TRecord, new()`; linq2db needs `class`. The compiler does not
-            // infer `class` transitively, so bridge via reflection (T is always a class at runtime).
-            var mi = typeof(Relational_Table<TRecord>)
-                .GetMethod(nameof(_QueryImpl), BindingFlags.NonPublic | BindingFlags.Instance)!
-                .MakeGenericMethod(typeof(T));
-            return mi.Invoke(this, null)!;
-        }
-
-        private object _QueryImpl<T>() where T : class, IRecord, new()
+        System.Linq.IQueryable<TRecord> ITable<TRecord>.Query()
         {
             // A DataContext (not DataConnection) backs the returned IQueryable: it opens/closes the
             // ADO connection per query, so the queryable can be composed and enumerated after this
             // method returns without holding a connection open.
             var ctx = new DataContext(_store.Options());
-            return ctx.GetTable<T>().TableName(_name);
+            return ctx.GetTable<TRecord>().TableName(_name);
         }
 
         /// <inheritdoc/>

--- a/interfaces/dotnet/PolyPersist/IAnalyticalStore.cs
+++ b/interfaces/dotnet/PolyPersist/IAnalyticalStore.cs
@@ -28,9 +28,5 @@ namespace PolyPersist
 		public Task<IAnalyticalTable<TRecord>> CreateTable<TRecord>( string tableName ) where TRecord: IAnalyticalRecord, new();
 		/// Drops an existing fact table.
 		public Task DropTable( string tableName );
-		/// ANALYTICAL query root spanning multiple tables (star-schema joins, cross-fact aggregation).
-		/// Deliberately NOT portable to non-relational stores; the return value is generic - in .NET
-		/// the linq2db DataConnection over which LINQ (and raw SQL) queries are written.
-		public object Query();
 	}
 }

--- a/interfaces/dotnet/PolyPersist/IAnalyticalTable.cs
+++ b/interfaces/dotnet/PolyPersist/IAnalyticalTable.cs
@@ -25,10 +25,9 @@ namespace PolyPersist
 		/// Bulk-appends a batch of fact rows. This is the only write path: OLAP engines are optimized
 		/// for batched ingestion, so callers should accumulate rows and append them together.
 		public Task InsertBatch( IList<TRecord> records );
-		/// Single-table analytical query (aggregation / GROUP BY / scan).
-		/// The return value is generic: in .NET an IQueryable<T> (linq2db -> dialect SQL). For raw SQL
-		/// use GetUnderlyingImplementation.
-		public object Query<T>() where T: TRecord, new();
+		/// Single-table analytical query (aggregation / GROUP BY / scan). Language-mapped:
+		/// .NET IQueryable<TRecord>, Java Stream<TRecord>, ...
+		public System.Linq.IQueryable<TRecord> Query();
 		/// Getting the underlying implementation.
 		/// Please use this method carefully, because the returned value is different in every
 		/// implementation (e.g. the linq2db DataConnection, or the raw DbConnection).

--- a/interfaces/dotnet/PolyPersist/IRelationalStore.cs
+++ b/interfaces/dotnet/PolyPersist/IRelationalStore.cs
@@ -39,10 +39,5 @@ namespace PolyPersist
 		///
 		/// @param tableName - The name of the table to be dropped.
 		public Task DropTable( string tableName );
-		/// RELATIONAL-ONLY query root for joins / multi-table / set-based SELECTs.
-		/// This is deliberately NOT portable to document/column stores, therefore it lives on the
-		/// relational store only. The return value is generic (in .NET the linq2db DataConnection,
-		/// over which LINQ joins are written; the same handle also serves raw SQL via Dapper).
-		public object Query();
 	}
 }

--- a/interfaces/dotnet/PolyPersist/ITable.cs
+++ b/interfaces/dotnet/PolyPersist/ITable.cs
@@ -13,7 +13,8 @@ namespace PolyPersist
 {
 	/// ITable defines CRUD and single-table query operations on a relational table.
 	/// This surface IS portable: it mirrors IDocumentCollection / IColumnTable, so cross-store code
-	/// keeps working. Joins are NOT here (they are not portable) - use IRelationalStore.Query().
+	/// keeps working. Query() returns the language-native queryable (LINQ in .NET); joins are written
+	/// in the host language over these queryables (advanced multi-table access via GetUnderlyingImplementation).
 	public interface ITable<TRecord>
 		where TRecord: IRecord, new()
 	{
@@ -33,10 +34,8 @@ namespace PolyPersist
 		/// Asynchronous method to find a row by its PartitionKey and id.
 		/// Returns the row if found, or null if not found.
 		public Task<TRecord> Find( string partitionKey, string id );
-		/// Portable, SINGLE-TABLE query interface (filter / project / order).
-		/// The return value is generic, so the implementation can define the real type:
-		/// in .NET an IQueryable<T>, in Java a Stream / Querydsl, etc.
-		public object Query<T>() where T: TRecord, new();
+		/// Portable, single-table query. Language-mapped: .NET IQueryable<TRecord>, Java Stream<TRecord>, ...
+		public System.Linq.IQueryable<TRecord> Query();
 		/// Getting the underlying implementation.
 		/// Please use this method carefully, because the returned value is different in every
 		/// implementation (e.g. the linq2db DataConnection, or the raw DbConnection for Dapper).

--- a/tests/dotnet/PolyPersist.Net.RelationalStore.Tests/RelationalTableTests.cs
+++ b/tests/dotnet/PolyPersist.Net.RelationalStore.Tests/RelationalTableTests.cs
@@ -162,7 +162,7 @@ namespace PolyPersist.Net.RelationalStore.Tests
             await table.Insert(Sample(pk: "p1", name: "mid", age: 40));
             await table.Insert(Sample(pk: "p1", name: "old", age: 60));
 
-            var query = (IQueryable<SampleRecord>)table.Query<SampleRecord>();
+            var query = table.Query();
             var adults = query.Where(r => r.Age >= 40).OrderBy(r => r.Age).ToList();
 
             Assert.AreEqual(2, adults.Count);
@@ -204,7 +204,7 @@ namespace PolyPersist.Net.RelationalStore.Tests
             await orders.Insert(new Order { PartitionKey = "p1", CustomerId = alice.id, Total = 20m });
 
             // Store-level Query() returns the linq2db DataConnection; write a LINQ join across tables.
-            using var db = (DataConnection)store.Query();
+            using var db = (DataConnection)orders.GetUnderlyingImplementation();
             var joined = await (
                 from o in db.GetTable<Order>().TableName(ordersName)
                 join c in db.GetTable<Customer>().TableName(customersName) on o.CustomerId equals c.id


### PR DESCRIPTION
Uses the new UniContract `query<T>` type for the portable single-table query (`ITable.Query()` / `IAnalyticalTable.Query()` → `System.Linq.IQueryable<TRecord>`) instead of `=> any`, and removes the store-level join root `Query() => any` from `IRelationalStore`/`IAnalyticalStore` (it leaked the linq2db DataConnection → not swappable; advanced joins go via `GetUnderlyingImplementation()`). Relational Dapper impl simplified (no reflection bridge). 50 relational tests green (SQLite + PostgreSQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)