### PR TITLE
Adopt query<T> in Document and ColumnStore contracts

### DIFF
--- a/contracts/ColumnStore.contract
+++ b/contracts/ColumnStore.contract
@@ -76,8 +76,8 @@ namespace PolyPersist {
 
         # Getting the query interface for table
         # the return value is generic, so the implementation can define what are the real types
-        # In dotnet is can be IQueryable, in java it can be Java Streams, or Querydsl etc...
-        method Query() => any
+        # Language-mapped: .NET IQueryable<TRow>, Java Stream<TRow>, Python Iterable[TRow].
+        method Query() => query<TRow>
 
         # getting the underlying implementation
         # please use this method carefully, because the returned value is different in every implementation

--- a/contracts/Document.contract
+++ b/contracts/Document.contract
@@ -71,8 +71,8 @@ namespace PolyPersist {
 
         # Getting the query interface for collection
         # the return value is generic, so the implementation can define what are the real types
-        # In dotnet is can be IQueryable, in java it can be Java Streams, or Querydsl etc...
-        method Query<T constraint TDocument instantiable>() => any
+        # Language-mapped: .NET IQueryable<TDocument>, Java Stream<TDocument>, Python Iterable[TDocument].
+        method Query() => query<TDocument>
 
         # getting the underlying implementation
         # please use this method carefully, because the returned value is different in every implementation

--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Cassandra_ColumnTable.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Cassandra/Cassandra_ColumnTable.cs
@@ -226,7 +226,7 @@ namespace PolyPersist.Net.ColumnStore.Cassandra
         }
 
         /// <inheritdoc/>
-        object IColumnTable<TRow>.Query()
+        System.Linq.IQueryable<TRow> IColumnTable<TRow>.Query()
         {
             return new Cassandra_Queryable<TRow,TRow>(this);
         }

--- a/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Memory/Memory_ColumnTable.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.ColumnStore.Memory/Memory_ColumnTable.cs
@@ -95,7 +95,7 @@ namespace PolyPersist.Net.ColumnStore.Memory
         }
 
         /// <inheritdoc/>
-        object IColumnTable<TRow>.Query()
+        System.Linq.IQueryable<TRow> IColumnTable<TRow>.Query()
         {
             var queryable = _tableData
                 .ListOfDocments

--- a/implementations/dotnet/src/PolyPersist.Net.DocumentStore.Memory/Memory_DocumentCollection.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.DocumentStore.Memory/Memory_DocumentCollection.cs
@@ -93,12 +93,12 @@ namespace PolyPersist.Net.DocumentStore.Memory
         }
 
         /// <inheritdoc/>
-        object IDocumentCollection<TDocument>.Query<T>()
+        System.Linq.IQueryable<TDocument> IDocumentCollection<TDocument>.Query()
         {
             return _collectionData
                 .ListOfDocments
                 .Select(data => JsonSerializer.Deserialize<TDocument>(data.Value, JsonOptionsProvider.Options()))
-                .OfType<T>()
+                .OfType<TDocument>()
                 .AsQueryable();
         }
 

--- a/implementations/dotnet/src/PolyPersist.Net.DocumentStore.MongoDB/MongoDB_DocumentCollection.cs
+++ b/implementations/dotnet/src/PolyPersist.Net.DocumentStore.MongoDB/MongoDB_DocumentCollection.cs
@@ -85,9 +85,9 @@ namespace PolyPersist.Net.DocumentStore.MongoDB
         }
 
         /// <inheritdoc/>
-        object IDocumentCollection<TDocument>.Query<T>()
+        System.Linq.IQueryable<TDocument> IDocumentCollection<TDocument>.Query()
         {
-            return _mongoCollection.OfType<T>().AsQueryable();
+            return _mongoCollection.OfType<TDocument>().AsQueryable();
         }
 
         /// <inheritdoc/>

--- a/interfaces/dotnet/PolyPersist/Extensions/DocumentCollectionExtensions.cs
+++ b/interfaces/dotnet/PolyPersist/Extensions/DocumentCollectionExtensions.cs
@@ -12,7 +12,7 @@
             if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
-            var query = collection.Query<TDocument>();
+            var query = collection.Query();
 
             if (query is IQueryable<TDocument> typedQuery)
             {
@@ -33,7 +33,7 @@
             if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
-            var query = collection.Query<TQueryType>();
+            var query = collection.Query().OfType<TQueryType>();
 
             if (query is IQueryable<TQueryType> typedQuery)
             {

--- a/interfaces/dotnet/PolyPersist/IColumnTable.cs
+++ b/interfaces/dotnet/PolyPersist/IColumnTable.cs
@@ -34,8 +34,8 @@ namespace PolyPersist
 		public Task<TRow> Find( string partitionKey, string id );
 		/// Getting the query interface for table
 		/// the return value is generic, so the implementation can define what are the real types
-		/// In dotnet is can be IQueryable, in java it can be Java Streams, or Querydsl etc...
-		public object Query();
+		/// Language-mapped: .NET IQueryable<TRow>, Java Stream<TRow>, Python Iterable[TRow].
+		public System.Linq.IQueryable<TRow> Query();
 		/// getting the underlying implementation
 		/// please use this method carefully, because the returned value is different in every implementation
 		public object GetUnderlyingImplementation();

--- a/interfaces/dotnet/PolyPersist/IDocumentCollection.cs
+++ b/interfaces/dotnet/PolyPersist/IDocumentCollection.cs
@@ -36,8 +36,8 @@ namespace PolyPersist
 		public Task<TDocument> Find( string partitionKey, string id );
 		/// Getting the query interface for collection
 		/// the return value is generic, so the implementation can define what are the real types
-		/// In dotnet is can be IQueryable, in java it can be Java Streams, or Querydsl etc...
-		public object Query<T>() where T: TDocument, new();
+		/// Language-mapped: .NET IQueryable<TDocument>, Java Stream<TDocument>, Python Iterable[TDocument].
+		public System.Linq.IQueryable<TDocument> Query();
 		/// getting the underlying implementation
 		/// please use this method carefully, because the returned value is different in every implementation
 		public object GetUnderlyingImplementation();

--- a/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
+++ b/tests/dotnet/PolyPersist.Net.Transactions.Tests/TransactionTests.cs
@@ -142,7 +142,7 @@ namespace PolyPersist.Net.Transactions.Tests
             public Task Update(TDoc document) => Task.CompletedTask;
             public Task Delete(string partitionKey, string id) { DeleteOrder.Add(id); return Task.CompletedTask; }
             public Task<TDoc> Find(string partitionKey, string id) => Task.FromResult(default(TDoc));
-            public object Query<T>() where T : TDoc, new() => null;
+            public System.Linq.IQueryable<TDoc> Query() => null;
             public object GetUnderlyingImplementation() => null;
         }
     }


### PR DESCRIPTION
Completes the `query<T>` rollout: `IDocumentCollection.Query()` and `IColumnTable.Query()` now return `System.Linq.IQueryable<TDocument/TRow>` instead of `=> any`. Mongo/Memory/Cassandra impls updated to the typed signature; the subtype-query extension overload uses standard LINQ `OfType<T>()`. All queryable stores now expose `query<T>`. Build clean; Transactions 8, Document 39 (Mongo+Memory), ColumnStore 64 (Scylla+Memory) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)